### PR TITLE
Add in-browser SQL debug console

### DIFF
--- a/invoice_classifier/templates/invoice_classifier/debug_sql.html
+++ b/invoice_classifier/templates/invoice_classifier/debug_sql.html
@@ -1,0 +1,112 @@
+<!DOCTYPE html>
+<html lang="es">
+  <head>
+    <meta charset="utf-8" />
+    <title>Consola SQL</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+        font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        line-height: 1.5;
+      }
+
+      body {
+        margin: 2rem auto;
+        max-width: 960px;
+        padding: 0 1rem 3rem;
+      }
+
+      textarea {
+        width: 100%;
+        min-height: 8rem;
+        font-family: "Fira Code", "SFMono-Regular", Consolas, "Liberation Mono", Menlo,
+          monospace;
+        font-size: 0.95rem;
+      }
+
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        margin-top: 1.5rem;
+      }
+
+      th,
+      td {
+        border: 1px solid currentColor;
+        padding: 0.5rem 0.75rem;
+        text-align: left;
+        vertical-align: top;
+      }
+
+      thead {
+        background: rgba(127, 127, 127, 0.2);
+      }
+
+      .actions {
+        margin-top: 0.75rem;
+        display: flex;
+        gap: 1rem;
+        align-items: center;
+      }
+
+      .error {
+        border-left: 4px solid #e53935;
+        background: rgba(229, 57, 53, 0.1);
+        padding: 0.75rem 1rem;
+        margin-top: 1.5rem;
+      }
+
+      .summary {
+        margin-top: 1.5rem;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Consola SQL de depuración</h1>
+    <p>
+      Ejecuta consultas SQL directamente contra la base de datos del proyecto. Úsalo sólo en
+      entornos de desarrollo.
+    </p>
+    <form method="post">
+      {% csrf_token %}
+      <label for="id-query"><strong>Consulta SQL</strong></label>
+      <textarea id="id-query" name="query" placeholder="SELECT * FROM ...">{{ query }}</textarea>
+      <div class="actions">
+        <button type="submit">Ejecutar</button>
+        {% if rowcount is not None %}
+        <span class="summary">Filas afectadas: {{ rowcount }}</span>
+        {% endif %}
+      </div>
+    </form>
+
+    {% if error_message %}
+    <div class="error">
+      <strong>Error al ejecutar la consulta:</strong>
+      <div>{{ error_message }}</div>
+    </div>
+    {% endif %}
+
+    {% if rows %}
+    <table>
+      <thead>
+        <tr>
+          {% for column in columns %}
+          <th>{{ column }}</th>
+          {% endfor %}
+        </tr>
+      </thead>
+      <tbody>
+        {% for row in rows %}
+        <tr>
+          {% for value in row %}
+          <td>{{ value }}</td>
+          {% endfor %}
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+    {% elif columns %}
+    <p class="summary">La consulta se ejecutó correctamente pero no devolvió registros.</p>
+    {% endif %}
+  </body>
+</html>

--- a/invoice_classifier/urls.py
+++ b/invoice_classifier/urls.py
@@ -5,5 +5,6 @@ from . import views
 urlpatterns = [
     path("", views.index, name="index"),
     path("api/imports/", views.upload_statement, name="upload_statement"),
+    path("debug/sql/", views.debug_sql_console, name="debug_sql_console"),
 ]
 

--- a/invoice_classifier/views.py
+++ b/invoice_classifier/views.py
@@ -8,7 +8,8 @@ from datetime import datetime
 from decimal import Decimal, InvalidOperation
 
 from django.core.files.base import ContentFile
-from django.db import transaction
+from django.db import connection, transaction
+from django.db.utils import DatabaseError
 from django.http import HttpRequest, HttpResponse, JsonResponse
 from django.shortcuts import render
 from django.views.decorators.csrf import ensure_csrf_cookie
@@ -138,3 +139,41 @@ def upload_statement(request: HttpRequest) -> JsonResponse:
         },
         status=201,
     )
+
+
+@require_http_methods(["GET", "POST"])
+@ensure_csrf_cookie
+def debug_sql_console(request: HttpRequest) -> HttpResponse:
+    """Render a simple SQL console for ad-hoc debugging queries."""
+
+    query = ""
+    error_message: str | None = None
+    columns: list[str] | None = None
+    rows: list[tuple[object, ...]] | None = None
+    rowcount: int | None = None
+
+    if request.method == "POST":
+        query = request.POST.get("query", "").strip()
+
+        if query:
+            try:
+                with connection.cursor() as cursor:
+                    cursor.execute(query)
+                    rowcount = cursor.rowcount
+                    if cursor.description:
+                        columns = [column[0] for column in cursor.description]
+                        rows = cursor.fetchall()
+            except DatabaseError as exc:
+                error_message = str(exc)
+        else:
+            error_message = "Introduce una consulta SQL para ejecutar."
+
+    context = {
+        "query": query,
+        "error_message": error_message,
+        "columns": columns,
+        "rows": rows,
+        "rowcount": rowcount,
+    }
+
+    return render(request, "invoice_classifier/debug_sql.html", context)


### PR DESCRIPTION
## Summary
- add a Django view that exposes a simple SQL console for development
- wire the console into the application URLs and provide a basic HTML interface

## Testing
- python manage.py check *(fails: missing Django dependency in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d741ea75fc832fb472d5e1e95df2a9