### PR TITLE
Add UI to manage classification criteria

### DIFF
--- a/invoice_classifier/forms.py
+++ b/invoice_classifier/forms.py
@@ -1,0 +1,54 @@
+"""Form helpers for the invoice classifier application."""
+
+from __future__ import annotations
+
+from django import forms
+
+from .models import ClassificationCriterion
+
+
+class ClassificationCriterionForm(forms.ModelForm):
+    """Form to create or update :class:`ClassificationCriterion` records."""
+
+    concept_keywords = forms.CharField(
+        label="Conceptos o palabras clave",
+        required=False,
+        widget=forms.Textarea(
+            attrs={
+                "rows": 4,
+                "placeholder": "Introduce una palabra o frase por línea",
+            }
+        ),
+        help_text="Cada línea se convertirá en una palabra clave para comparar con el concepto.",
+    )
+
+    class Meta:
+        model = ClassificationCriterion
+        fields = [
+            "name",
+            "slug",
+            "description",
+            "concept_keywords",
+            "min_amount",
+            "max_amount",
+        ]
+        widgets = {
+            "description": forms.Textarea(attrs={"rows": 3}),
+        }
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        if not self.is_bound and self.instance.pk:
+            self.initial["concept_keywords"] = "\n".join(self.instance.concept_keywords or [])
+
+    def clean_concept_keywords(self) -> list[str]:
+        data = self.cleaned_data.get("concept_keywords", "")
+        keywords = [line.strip() for line in data.splitlines() if line.strip()]
+        return keywords
+
+    def save(self, commit: bool = True) -> ClassificationCriterion:
+        instance: ClassificationCriterion = super().save(commit=False)
+        instance.concept_keywords = self.cleaned_data.get("concept_keywords", [])
+        if commit:
+            instance.save()
+        return instance

--- a/invoice_classifier/migrations/0002_classificationcriterion_add_fields.py
+++ b/invoice_classifier/migrations/0002_classificationcriterion_add_fields.py
@@ -1,0 +1,42 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("invoice_classifier", "0001_initial"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="classificationcriterion",
+            name="concept_keywords",
+            field=models.JSONField(
+                blank=True,
+                default=list,
+                help_text="Lista de conceptos o palabras clave asociadas al criterio.",
+            ),
+        ),
+        migrations.AddField(
+            model_name="classificationcriterion",
+            name="max_amount",
+            field=models.DecimalField(
+                blank=True,
+                decimal_places=2,
+                help_text="Importe máximo (inclusive) para considerar el criterio.",
+                max_digits=12,
+                null=True,
+            ),
+        ),
+        migrations.AddField(
+            model_name="classificationcriterion",
+            name="min_amount",
+            field=models.DecimalField(
+                blank=True,
+                decimal_places=2,
+                help_text="Importe mínimo (inclusive) para considerar el criterio.",
+                max_digits=12,
+                null=True,
+            ),
+        ),
+    ]

--- a/invoice_classifier/models.py
+++ b/invoice_classifier/models.py
@@ -1,4 +1,4 @@
-from django.db import models
+from django.db import models, transaction
 from django.utils import timezone
 
 class StatementImport(models.Model):
@@ -85,6 +85,25 @@ class ClassificationCriterion(models.Model):
     name = models.CharField(max_length=100, unique=True)
     slug = models.SlugField(max_length=100, unique=True)
     description = models.TextField(blank=True)
+    concept_keywords = models.JSONField(
+        default=list,
+        blank=True,
+        help_text="Lista de conceptos o palabras clave asociadas al criterio.",
+    )
+    min_amount = models.DecimalField(
+        max_digits=12,
+        decimal_places=2,
+        null=True,
+        blank=True,
+        help_text="Importe mínimo (inclusive) para considerar el criterio.",
+    )
+    max_amount = models.DecimalField(
+        max_digits=12,
+        decimal_places=2,
+        null=True,
+        blank=True,
+        help_text="Importe máximo (inclusive) para considerar el criterio.",
+    )
 
     class Meta:
         ordering = ("name",)
@@ -93,6 +112,102 @@ class ClassificationCriterion(models.Model):
 
     def __str__(self) -> str:
         return self.name
+
+    def normalized_keywords(self) -> list[str]:
+        """Return the list of keywords in lowercase without empty values."""
+
+        raw_keywords = self.concept_keywords or []
+        normalized: list[str] = []
+        for keyword in raw_keywords:
+            value = str(keyword).strip()
+            if value:
+                normalized.append(value.lower())
+        return normalized
+
+    def matches_transaction(self, transaction: "BankTransaction") -> bool:
+        """Return ``True`` if the given transaction matches this criterion."""
+
+        keywords = self.normalized_keywords()
+        if keywords:
+            concept_parts = [
+                (transaction.normalized_concept or "").lower(),
+                (transaction.concept or "").lower(),
+            ]
+            concept_text = " ".join(part for part in concept_parts if part)
+            if not any(keyword in concept_text for keyword in keywords):
+                return False
+
+        if self.min_amount is not None and transaction.amount < self.min_amount:
+            return False
+
+        if self.max_amount is not None and transaction.amount > self.max_amount:
+            return False
+
+        return True
+
+    def get_or_create_default_label(self) -> "ClassificationLabel":
+        """Return a label to use for automatic classifications."""
+
+        default_slug = f"auto-{self.slug}"
+        label = self.labels.filter(slug=default_slug).first()
+        if label:
+            update_fields: list[str] = []
+            if label.name != self.name:
+                label.name = self.name
+                update_fields.append("name")
+            description = self.description or "Etiqueta generada automáticamente a partir del criterio."
+            if label.description != description:
+                label.description = description
+                update_fields.append("description")
+            if update_fields:
+                label.save(update_fields=update_fields)
+            return label
+
+        fallback = self.labels.filter(slug__startswith="auto-").first()
+        if fallback:
+            fallback.slug = default_slug
+            fallback.name = self.name
+            fallback.description = (
+                self.description or "Etiqueta generada automáticamente a partir del criterio."
+            )
+            fallback.save(update_fields=["slug", "name", "description"])
+            return fallback
+
+        return self.labels.create(
+            name=self.name,
+            slug=default_slug,
+            description=self.description or "Etiqueta generada automáticamente a partir del criterio.",
+        )
+
+    def classify_unclassified_transactions(self) -> int:
+        """Classify unclassified transactions that match this criterion."""
+
+        label = self.get_or_create_default_label()
+        unclassified = (
+            BankTransaction.objects.filter(classifications__isnull=True)
+            .only("id", "concept", "normalized_concept", "amount")
+            .iterator(chunk_size=200)
+        )
+
+        to_create: list["TransactionClassification"] = []
+        for transaction in unclassified:
+            if self.matches_transaction(transaction):
+                to_create.append(
+                    TransactionClassification(
+                        transaction=transaction,
+                        label=label,
+                        source=TransactionClassification.Sources.AUTOMATIC,
+                        confidence=1,
+                    )
+                )
+
+        if not to_create:
+            return 0
+
+        with transaction.atomic():
+            TransactionClassification.objects.bulk_create(to_create, ignore_conflicts=True)
+
+        return len(to_create)
 
 
 class ClassificationLabel(models.Model):

--- a/invoice_classifier/templates/invoice_classifier/manage_criteria.html
+++ b/invoice_classifier/templates/invoice_classifier/manage_criteria.html
@@ -7,7 +7,7 @@
     <title>Gestión de criterios de clasificación</title>
     <style>
       :root {
-        color-scheme: light dark;
+        color-scheme: light;
         font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
         line-height: 1.5;
       }

--- a/invoice_classifier/templates/invoice_classifier/manage_criteria.html
+++ b/invoice_classifier/templates/invoice_classifier/manage_criteria.html
@@ -216,8 +216,8 @@
 
             {% for field in create_form %}
               <div>
-                <label for="id_create_{{ field.name }}">{{ field.label }}</label>
-                {{ field.as_widget(attrs={"id": "id_create_"|add:field.name}) }}
+                <label for="{{ field.id_for_label }}">{{ field.label }}</label>
+                {{ field }}
                 {% if field.help_text %}
                   <p class="helptext">{{ field.help_text }}</p>
                 {% endif %}
@@ -240,8 +240,8 @@
 
               {% for field in edit_form %}
                 <div>
-                  <label for="id_edit_{{ field.name }}">{{ field.label }}</label>
-                  {{ field.as_widget(attrs={"id": "id_edit_"|add:field.name}) }}
+                  <label for="{{ field.id_for_label }}">{{ field.label }}</label>
+                  {{ field }}
                   {% if field.help_text %}
                     <p class="helptext">{{ field.help_text }}</p>
                   {% endif %}

--- a/invoice_classifier/templates/invoice_classifier/manage_criteria.html
+++ b/invoice_classifier/templates/invoice_classifier/manage_criteria.html
@@ -1,0 +1,325 @@
+<!DOCTYPE html>
+{% load static %}
+<html lang="es">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Gestión de criterios de clasificación</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+        font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        line-height: 1.5;
+      }
+
+      body {
+        margin: 0;
+        background: #f4f4f5;
+        padding: 2rem;
+      }
+
+      main {
+        max-width: 1200px;
+        margin: 0 auto;
+      }
+
+      h1 {
+        margin-top: 0;
+        font-size: 2rem;
+      }
+
+      .messages {
+        list-style: none;
+        padding: 0;
+        margin: 1rem 0;
+      }
+
+      .messages li {
+        background: #ecfdf5;
+        border: 1px solid #34d399;
+        color: #065f46;
+        padding: 0.75rem 1rem;
+        border-radius: 0.75rem;
+        margin-bottom: 0.5rem;
+      }
+
+      .panels {
+        display: grid;
+        gap: 1.5rem;
+        grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+      }
+
+      .panel {
+        background: #ffffff;
+        border-radius: 1rem;
+        padding: 1.5rem;
+        box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+      }
+
+      form {
+        display: grid;
+        gap: 1rem;
+      }
+
+      label {
+        font-weight: 600;
+        display: block;
+        margin-bottom: 0.35rem;
+      }
+
+      input[type="text"],
+      textarea,
+      input[type="number"] {
+        width: 100%;
+        padding: 0.6rem 0.75rem;
+        border-radius: 0.5rem;
+        border: 1px solid #d4d4d8;
+        font-size: 0.95rem;
+        box-sizing: border-box;
+      }
+
+      textarea {
+        resize: vertical;
+      }
+
+      .helptext {
+        font-size: 0.8rem;
+        color: #52525b;
+      }
+
+      .errorlist {
+        margin: 0.25rem 0 0;
+        padding-left: 1.1rem;
+        color: #b91c1c;
+        font-size: 0.85rem;
+      }
+
+      button {
+        justify-self: start;
+        background: #2563eb;
+        color: #ffffff;
+        border: none;
+        border-radius: 0.5rem;
+        padding: 0.6rem 1.25rem;
+        font-size: 0.95rem;
+        cursor: pointer;
+        transition: background 0.2s ease;
+      }
+
+      button:hover {
+        background: #1d4ed8;
+      }
+
+      .criteria-list {
+        margin-top: 1.5rem;
+      }
+
+      .criteria-list ul {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+        display: grid;
+        gap: 0.75rem;
+      }
+
+      .criteria-item {
+        border: 1px solid #e4e4e7;
+        border-radius: 0.75rem;
+        padding: 0.75rem 1rem;
+        background: #fafafa;
+      }
+
+      .criteria-item strong {
+        display: block;
+        font-size: 1rem;
+        margin-bottom: 0.2rem;
+      }
+
+      .criteria-item a {
+        color: #2563eb;
+        text-decoration: none;
+        font-weight: 600;
+      }
+
+      .transactions {
+        margin-top: 2rem;
+      }
+
+      .transaction-list {
+        background: #ffffff;
+        border-radius: 1rem;
+        padding: 1rem;
+        box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+        max-height: 420px;
+        overflow-y: auto;
+      }
+
+      table {
+        width: 100%;
+        border-collapse: collapse;
+      }
+
+      th,
+      td {
+        text-align: left;
+        padding: 0.5rem 0.75rem;
+        border-bottom: 1px solid #e4e4e7;
+        font-size: 0.9rem;
+      }
+
+      th {
+        position: sticky;
+        top: 0;
+        background: #ffffff;
+        z-index: 1;
+      }
+
+      tr:last-child td {
+        border-bottom: none;
+      }
+
+      @media (max-width: 720px) {
+        body {
+          padding: 1rem;
+        }
+
+        .transaction-list {
+          max-height: 320px;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Gestión de criterios de clasificación</h1>
+      <p>
+        Crea reglas basadas en conceptos y rangos de importes. Cada vez que guardes un
+        criterio se revisarán los movimientos sin clasificar para aplicar la etiqueta
+        correspondiente de forma automática.
+      </p>
+
+      {% if messages %}
+        <ul class="messages">
+          {% for message in messages %}
+            <li>{{ message }}</li>
+          {% endfor %}
+        </ul>
+      {% endif %}
+
+      <div class="panels">
+        <section class="panel">
+          <h2>Nuevo criterio</h2>
+          <form method="post">
+            {% csrf_token %}
+            <input type="hidden" name="mode" value="create" />
+            {{ create_form.non_field_errors }}
+
+            {% for field in create_form %}
+              <div>
+                <label for="id_create_{{ field.name }}">{{ field.label }}</label>
+                {{ field.as_widget(attrs={"id": "id_create_"|add:field.name}) }}
+                {% if field.help_text %}
+                  <p class="helptext">{{ field.help_text }}</p>
+                {% endif %}
+                {{ field.errors }}
+              </div>
+            {% endfor %}
+
+            <button type="submit">Guardar criterio</button>
+          </form>
+        </section>
+
+        <section class="panel">
+          <h2>Editar criterio</h2>
+          {% if edit_form and edit_instance %}
+            <form method="post">
+              {% csrf_token %}
+              <input type="hidden" name="mode" value="update" />
+              <input type="hidden" name="criterion_id" value="{{ edit_instance.pk }}" />
+              {{ edit_form.non_field_errors }}
+
+              {% for field in edit_form %}
+                <div>
+                  <label for="id_edit_{{ field.name }}">{{ field.label }}</label>
+                  {{ field.as_widget(attrs={"id": "id_edit_"|add:field.name}) }}
+                  {% if field.help_text %}
+                    <p class="helptext">{{ field.help_text }}</p>
+                  {% endif %}
+                  {{ field.errors }}
+                </div>
+              {% endfor %}
+
+              <button type="submit">Actualizar criterio</button>
+            </form>
+          {% else %}
+            <p>Selecciona un criterio de la lista inferior para editarlo.</p>
+          {% endif %}
+
+          <div class="criteria-list">
+            <h3>Listado de criterios</h3>
+            <ul>
+              {% for criterion in criteria_list %}
+                <li class="criteria-item">
+                  <strong>{{ criterion.name }}</strong>
+                  <div>
+                    <small>Slug: {{ criterion.slug }}</small>
+                  </div>
+                  {% if criterion.description %}
+                    <p>{{ criterion.description }}</p>
+                  {% endif %}
+                  {% if criterion.concept_keywords %}
+                    <p>
+                      <strong>Palabras clave:</strong>
+                      {{ criterion.concept_keywords|join:", " }}
+                    </p>
+                  {% endif %}
+                  <p>
+                    {% if criterion.min_amount %}
+                      Mín: {{ criterion.min_amount }}
+                    {% endif %}
+                    {% if criterion.max_amount %}
+                      Máx: {{ criterion.max_amount }}
+                    {% endif %}
+                  </p>
+                  <a href="?edit={{ criterion.pk }}">Editar</a>
+                </li>
+              {% empty %}
+                <li>No hay criterios definidos todavía.</li>
+              {% endfor %}
+            </ul>
+          </div>
+        </section>
+      </div>
+
+      <section class="transactions">
+        <h2>Movimientos sin clasificar ({{ unclassified_count }})</h2>
+        <div class="transaction-list">
+          {% if unclassified_count %}
+            <table>
+              <thead>
+                <tr>
+                  <th>Fecha</th>
+                  <th>Concepto</th>
+                  <th>Importe</th>
+                  <th>Importación</th>
+                </tr>
+              </thead>
+              <tbody>
+                {% for transaction in unclassified_transactions %}
+                  <tr>
+                    <td>{{ transaction.booking_date|date:"d/m/Y" }}</td>
+                    <td>{{ transaction.concept }}</td>
+                    <td>{{ transaction.amount }}</td>
+                    <td>{{ transaction.statement.source_name }}</td>
+                  </tr>
+                {% endfor %}
+              </tbody>
+            </table>
+          {% else %}
+            <p>No hay movimientos pendientes de clasificar.</p>
+          {% endif %}
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/invoice_classifier/urls.py
+++ b/invoice_classifier/urls.py
@@ -6,5 +6,10 @@ urlpatterns = [
     path("", views.index, name="index"),
     path("api/imports/", views.upload_statement, name="upload_statement"),
     path("debug/sql/", views.debug_sql_console, name="debug_sql_console"),
+    path(
+        "criterios/",
+        views.manage_classification_criteria,
+        name="manage_classification_criteria",
+    ),
 ]
 

--- a/invoice_classifier/views.py
+++ b/invoice_classifier/views.py
@@ -195,7 +195,7 @@ def manage_classification_criteria(request: HttpRequest) -> HttpResponse:
     )
     unclassified_count = unclassified_transactions_qs.count()
 
-    create_form = ClassificationCriterionForm()
+    create_form = ClassificationCriterionForm(prefix="create")
     edit_form: ClassificationCriterionForm | None = None
     edit_instance: ClassificationCriterion | None = None
 
@@ -205,10 +205,12 @@ def manage_classification_criteria(request: HttpRequest) -> HttpResponse:
             edit_instance = get_object_or_404(
                 ClassificationCriterion, pk=request.POST.get("criterion_id")
             )
-            edit_form = ClassificationCriterionForm(request.POST, instance=edit_instance)
+            edit_form = ClassificationCriterionForm(
+                request.POST, instance=edit_instance, prefix="edit"
+            )
             form = edit_form
         else:
-            form = ClassificationCriterionForm(request.POST)
+            form = ClassificationCriterionForm(request.POST, prefix="create")
             create_form = form
 
         if form.is_valid():
@@ -236,7 +238,7 @@ def manage_classification_criteria(request: HttpRequest) -> HttpResponse:
         edit_id = request.GET.get("edit")
         if edit_id:
             edit_instance = get_object_or_404(ClassificationCriterion, pk=edit_id)
-            edit_form = ClassificationCriterionForm(instance=edit_instance)
+            edit_form = ClassificationCriterionForm(instance=edit_instance, prefix="edit")
 
     context = {
         "criteria_list": criteria_list,

--- a/invoice_classifier/views.py
+++ b/invoice_classifier/views.py
@@ -7,15 +7,18 @@ import io
 from datetime import datetime
 from decimal import Decimal, InvalidOperation
 
+from django.contrib import messages
 from django.core.files.base import ContentFile
 from django.db import connection, transaction
 from django.db.utils import DatabaseError
 from django.http import HttpRequest, HttpResponse, JsonResponse
-from django.shortcuts import render
+from django.shortcuts import get_object_or_404, redirect, render
+from django.urls import reverse
 from django.views.decorators.csrf import ensure_csrf_cookie
 from django.views.decorators.http import require_http_methods
 
-from .models import BankTransaction, StatementImport
+from .forms import ClassificationCriterionForm
+from .models import BankTransaction, ClassificationCriterion, StatementImport
 
 
 @ensure_csrf_cookie
@@ -177,3 +180,71 @@ def debug_sql_console(request: HttpRequest) -> HttpResponse:
     }
 
     return render(request, "invoice_classifier/debug_sql.html", context)
+
+
+@require_http_methods(["GET", "POST"])
+@ensure_csrf_cookie
+def manage_classification_criteria(request: HttpRequest) -> HttpResponse:
+    """Allow users to create and update classification criteria."""
+
+    criteria_list = ClassificationCriterion.objects.all().order_by("name")
+    unclassified_transactions_qs = (
+        BankTransaction.objects.filter(classifications__isnull=True)
+        .select_related("statement")
+        .order_by("-booking_date", "-id")
+    )
+    unclassified_count = unclassified_transactions_qs.count()
+
+    create_form = ClassificationCriterionForm()
+    edit_form: ClassificationCriterionForm | None = None
+    edit_instance: ClassificationCriterion | None = None
+
+    if request.method == "POST":
+        mode = request.POST.get("mode", "create")
+        if mode == "update":
+            edit_instance = get_object_or_404(
+                ClassificationCriterion, pk=request.POST.get("criterion_id")
+            )
+            edit_form = ClassificationCriterionForm(request.POST, instance=edit_instance)
+            form = edit_form
+        else:
+            form = ClassificationCriterionForm(request.POST)
+            create_form = form
+
+        if form.is_valid():
+            criterion = form.save()
+            classified_count = criterion.classify_unclassified_transactions()
+            if mode == "update":
+                messages.success(
+                    request,
+                    (
+                        f"Criterio «{criterion.name}» actualizado. "
+                        f"{classified_count} movimientos clasificados automáticamente."
+                    ),
+                )
+                return redirect(f"{reverse('manage_classification_criteria')}?edit={criterion.pk}")
+
+            messages.success(
+                request,
+                (
+                    f"Criterio «{criterion.name}» creado. "
+                    f"{classified_count} movimientos clasificados automáticamente."
+                ),
+            )
+            return redirect(reverse("manage_classification_criteria"))
+    else:
+        edit_id = request.GET.get("edit")
+        if edit_id:
+            edit_instance = get_object_or_404(ClassificationCriterion, pk=edit_id)
+            edit_form = ClassificationCriterionForm(instance=edit_instance)
+
+    context = {
+        "criteria_list": criteria_list,
+        "create_form": create_form,
+        "edit_form": edit_form,
+        "edit_instance": edit_instance,
+        "unclassified_transactions": unclassified_transactions_qs,
+        "unclassified_count": unclassified_count,
+    }
+
+    return render(request, "invoice_classifier/manage_criteria.html", context)


### PR DESCRIPTION
## Summary
- add form helpers and model methods to evaluate classification criteria and classify matching transactions automatically
- expose a management view with creation and edition forms plus a scrollable list of unclassified transactions
- wire the new view into the URL configuration and add the accompanying template styling

## Testing
- python -m compileall invoice_classifier
- python manage.py check *(fails: Django not installed in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d746837524832fb64422beaf4f6524