### PR TITLE
Add shared base template and navigation bar

### DIFF
--- a/invoice_classifier/static/invoice_classifier/index.css
+++ b/invoice_classifier/static/invoice_classifier/index.css
@@ -3,15 +3,24 @@
   font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
 }
 
-body {
+body.index-body {
   margin: 0;
   background: #0f172a;
   color: #f8fafc;
-  min-height: 100vh;
+}
+
+.content--index {
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 2rem 1rem;
+  width: min(780px, 100%);
+  min-height: calc(100vh - 180px);
+  padding: 3rem 0;
+}
+
+#index-app,
+#app {
+  width: 100%;
 }
 
 .card {
@@ -117,4 +126,15 @@ button[disabled] {
 
 .result dd {
   margin: 0 0 0.75rem;
+}
+
+@media (max-width: 640px) {
+  .card {
+    padding: 2rem 1.5rem;
+  }
+
+  .content--index {
+    padding: 2.5rem 0;
+    min-height: calc(100vh - 200px);
+  }
 }

--- a/invoice_classifier/static/invoice_classifier/index.css
+++ b/invoice_classifier/static/invoice_classifier/index.css
@@ -15,7 +15,7 @@ body.index-body {
   justify-content: center;
   width: min(780px, 100%);
   min-height: calc(100vh - 180px);
-  padding: 3rem 0;
+  padding: 0rem 0rem 15rem 0rem;
 }
 
 #index-app,

--- a/invoice_classifier/templates/invoice_classifier/base.html
+++ b/invoice_classifier/templates/invoice_classifier/base.html
@@ -1,0 +1,59 @@
+{% load static %}
+<!DOCTYPE html>
+<html lang="es">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{% block title %}Bank Informer{% endblock %}</title>
+    <style>
+      :root {
+        color-scheme: light;
+        font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont,
+          "Segoe UI", sans-serif;
+        line-height: 1.5;
+        background-color: #f4f4f5;
+      }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        background: #f4f4f5;
+        color: #0f172a;
+      }
+
+      a {
+        color: inherit;
+      }
+
+      .layout {
+        min-height: 100vh;
+        display: flex;
+        flex-direction: column;
+      }
+
+      .content {
+        flex: 1;
+        width: min(1100px, calc(100% - 3rem));
+        margin: 0 auto;
+        padding: 2rem 0 3rem;
+      }
+
+      @media (max-width: 720px) {
+        .content {
+          width: min(100%, calc(100% - 2rem));
+          padding: 1.5rem 0 2rem;
+        }
+      }
+    </style>
+    {% block extra_head %}{% endblock %}
+  </head>
+  <body class="{% block body_class %}{% endblock %}">
+    <div class="layout">
+      {% block navbar %}{% include "invoice_classifier/partials/navbar.html" %}{% endblock %}
+      <main class="content {% block content_class %}{% endblock %}">
+        {% block content %}{% endblock %}
+      </main>
+    </div>
+    {% block extra_scripts %}{% endblock %}
+  </body>
+</html>

--- a/invoice_classifier/templates/invoice_classifier/debug_sql.html
+++ b/invoice_classifier/templates/invoice_classifier/debug_sql.html
@@ -1,67 +1,80 @@
-<!DOCTYPE html>
-<html lang="es">
-  <head>
-    <meta charset="utf-8" />
-    <title>Consola SQL</title>
-    <style>
-      :root {
-        color-scheme: light dark;
-        font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-        line-height: 1.5;
-      }
+{% extends "invoice_classifier/base.html" %}
 
-      body {
-        margin: 2rem auto;
-        max-width: 960px;
-        padding: 0 1rem 3rem;
-      }
+{% block title %}Consola SQL{% endblock %}
 
-      textarea {
-        width: 100%;
-        min-height: 8rem;
-        font-family: "Fira Code", "SFMono-Regular", Consolas, "Liberation Mono", Menlo,
-          monospace;
-        font-size: 0.95rem;
-      }
+{% block navbar %}
+  {% include "invoice_classifier/partials/navbar.html" with active_page="sql" %}
+{% endblock %}
 
-      table {
-        width: 100%;
-        border-collapse: collapse;
-        margin-top: 1.5rem;
-      }
+{% block extra_head %}
+  {{ block.super }}
+  <style>
+    .debug-sql h1 {
+      margin-top: 0;
+    }
 
-      th,
-      td {
-        border: 1px solid currentColor;
-        padding: 0.5rem 0.75rem;
-        text-align: left;
-        vertical-align: top;
-      }
+    .debug-sql textarea {
+      width: 100%;
+      min-height: 8rem;
+      font-family: "Fira Code", "SFMono-Regular", Consolas, "Liberation Mono", Menlo,
+        monospace;
+      font-size: 0.95rem;
+    }
 
-      thead {
-        background: rgba(127, 127, 127, 0.2);
-      }
+    .debug-sql table {
+      width: 100%;
+      border-collapse: collapse;
+      margin-top: 1.5rem;
+    }
 
-      .actions {
-        margin-top: 0.75rem;
-        display: flex;
-        gap: 1rem;
-        align-items: center;
-      }
+    .debug-sql th,
+    .debug-sql td {
+      border: 1px solid currentColor;
+      padding: 0.5rem 0.75rem;
+      text-align: left;
+      vertical-align: top;
+    }
 
-      .error {
-        border-left: 4px solid #e53935;
-        background: rgba(229, 57, 53, 0.1);
-        padding: 0.75rem 1rem;
-        margin-top: 1.5rem;
-      }
+    .debug-sql thead {
+      background: rgba(127, 127, 127, 0.2);
+    }
 
-      .summary {
-        margin-top: 1.5rem;
-      }
-    </style>
-  </head>
-  <body>
+    .debug-sql .actions {
+      margin-top: 0.75rem;
+      display: flex;
+      gap: 1rem;
+      align-items: center;
+    }
+
+    .debug-sql button {
+      padding: 0.55rem 1.25rem;
+      border-radius: 0.5rem;
+      border: none;
+      cursor: pointer;
+      background: #2563eb;
+      color: #ffffff;
+      font-size: 0.95rem;
+    }
+
+    .debug-sql button:hover {
+      background: #1d4ed8;
+    }
+
+    .debug-sql .error {
+      border-left: 4px solid #e53935;
+      background: rgba(229, 57, 53, 0.1);
+      padding: 0.75rem 1rem;
+      margin-top: 1.5rem;
+    }
+
+    .debug-sql .summary {
+      margin-top: 1.5rem;
+    }
+  </style>
+{% endblock %}
+
+{% block content %}
+  <div class="debug-sql">
     <h1>Consola SQL de depuración</h1>
     <p>
       Ejecuta consultas SQL directamente contra la base de datos del proyecto. Úsalo sólo en
@@ -74,39 +87,39 @@
       <div class="actions">
         <button type="submit">Ejecutar</button>
         {% if rowcount is not None %}
-        <span class="summary">Filas afectadas: {{ rowcount }}</span>
+          <span class="summary">Filas afectadas: {{ rowcount }}</span>
         {% endif %}
       </div>
     </form>
 
     {% if error_message %}
-    <div class="error">
-      <strong>Error al ejecutar la consulta:</strong>
-      <div>{{ error_message }}</div>
-    </div>
+      <div class="error">
+        <strong>Error al ejecutar la consulta:</strong>
+        <div>{{ error_message }}</div>
+      </div>
     {% endif %}
 
     {% if rows %}
-    <table>
-      <thead>
-        <tr>
-          {% for column in columns %}
-          <th>{{ column }}</th>
+      <table>
+        <thead>
+          <tr>
+            {% for column in columns %}
+              <th>{{ column }}</th>
+            {% endfor %}
+          </tr>
+        </thead>
+        <tbody>
+          {% for row in rows %}
+            <tr>
+              {% for value in row %}
+                <td>{{ value }}</td>
+              {% endfor %}
+            </tr>
           {% endfor %}
-        </tr>
-      </thead>
-      <tbody>
-        {% for row in rows %}
-        <tr>
-          {% for value in row %}
-          <td>{{ value }}</td>
-          {% endfor %}
-        </tr>
-        {% endfor %}
-      </tbody>
-    </table>
+        </tbody>
+      </table>
     {% elif columns %}
-    <p class="summary">La consulta se ejecutó correctamente pero no devolvió registros.</p>
+      <p class="summary">La consulta se ejecutó correctamente pero no devolvió registros.</p>
     {% endif %}
-  </body>
-</html>
+  </div>
+{% endblock %}

--- a/invoice_classifier/templates/invoice_classifier/index.html
+++ b/invoice_classifier/templates/invoice_classifier/index.html
@@ -1,70 +1,81 @@
-<!DOCTYPE html>
+{% extends "invoice_classifier/base.html" %}
 {% load static %}
-<html lang="es">
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Importador bancario</title>
-    <script src="https://unpkg.com/vue@3/dist/vue.global.prod.js" defer></script>
-    <link rel="stylesheet" href="{% static 'invoice_classifier/index.css' %}" />
-  </head>
-  <body>
-    <div id="app" data-upload-url="{% url 'upload_statement' %}">
-      <div class="card">
-        <h1>Importador de movimientos bancarios</h1>
-        <p>
-          Sube un CSV exportado de tu banco con las columnas <strong>Concepto</strong>,
-          <strong>Fecha</strong>, <strong>Importe</strong> y <strong>Saldo disponible</strong>.
-        </p>
 
-        <form @submit.prevent="submitForm" novalidate>
-          <div class="form-group">
-            <label for="source-name">Nombre de la importación</label>
-            <input
-              id="source-name"
-              type="text"
-              v-model="sourceName"
-              placeholder="Cuenta corriente principal"
-              autocomplete="off"
-              required
-            />
-          </div>
+{% block title %}Importador bancario{% endblock %}
 
-          <div class="form-group">
-            <label for="csv-file">Archivo CSV</label>
-            <input
-              id="csv-file"
-              type="file"
-              accept=".csv,text/csv"
-              @change="onFileChange"
-              ref="fileInput"
-              required
-            />
-          </div>
+{% block body_class %}index-body{% endblock %}
 
-          <button type="submit" :disabled="isSubmitting || !file">
-            <span v-if="isSubmitting">Procesando…</span>
-            <span v-else>Subir CSV</span>
-          </button>
-        </form>
+{% block content_class %}content--index{% endblock %}
 
-        <div v-if="message" class="message" :class="messageType">
-          {{ message }}
+{% block extra_head %}
+  {{ block.super }}
+  <script src="https://unpkg.com/vue@3/dist/vue.global.prod.js" defer></script>
+  <link rel="stylesheet" href="{% static 'invoice_classifier/index.css' %}" />
+{% endblock %}
+
+{% block navbar %}
+  {% include "invoice_classifier/partials/navbar.html" with active_page="index" %}
+{% endblock %}
+
+{% block content %}
+  <div id="app" data-upload-url="{% url 'upload_statement' %}">
+    <div class="card">
+      <h1>Importador de movimientos bancarios</h1>
+      <p>
+        Sube un CSV exportado de tu banco con las columnas <strong>Concepto</strong>,
+        <strong>Fecha</strong>, <strong>Importe</strong> y <strong>Saldo disponible</strong>.
+      </p>
+
+      <form @submit.prevent="submitForm" novalidate>
+        <div class="form-group">
+          <label for="source-name">Nombre de la importación</label>
+          <input
+            id="source-name"
+            type="text"
+            v-model="sourceName"
+            placeholder="Cuenta corriente principal"
+            autocomplete="off"
+            required
+          />
         </div>
 
-        <dl v-if="result" class="result">
-          <div>
-            <dt>Importación</dt>
-            <dd>#{{ result.statement_id }} · {{ result.file_name }}</dd>
-          </div>
-          <div>
-            <dt>Movimientos creados</dt>
-            <dd>{{ result.transactions_created }}</dd>
-          </div>
-        </dl>
-      </div>
-    </div>
+        <div class="form-group">
+          <label for="csv-file">Archivo CSV</label>
+          <input
+            id="csv-file"
+            type="file"
+            accept=".csv,text/csv"
+            @change="onFileChange"
+            ref="fileInput"
+            required
+          />
+        </div>
 
-    <script src="{% static 'invoice_classifier/statement_upload.js' %}" defer></script>
-  </body>
-</html>
+        <button type="submit" :disabled="isSubmitting || !file">
+          <span v-if="isSubmitting">Procesando…</span>
+          <span v-else>Subir CSV</span>
+        </button>
+      </form>
+
+      <div v-if="message" class="message" :class="messageType">
+        {{ message }}
+      </div>
+
+      <dl v-if="result" class="result">
+        <div>
+          <dt>Importación</dt>
+          <dd>#{{ result.statement_id }} · {{ result.file_name }}</dd>
+        </div>
+        <div>
+          <dt>Movimientos creados</dt>
+          <dd>{{ result.transactions_created }}</dd>
+        </div>
+      </dl>
+    </div>
+  </div>
+{% endblock %}
+
+{% block extra_scripts %}
+  {{ block.super }}
+  <script src="{% static 'invoice_classifier/statement_upload.js' %}" defer></script>
+{% endblock %}

--- a/invoice_classifier/templates/invoice_classifier/manage_criteria.html
+++ b/invoice_classifier/templates/invoice_classifier/manage_criteria.html
@@ -1,220 +1,235 @@
-<!DOCTYPE html>
-{% load static %}
-<html lang="es">
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Gestión de criterios de clasificación</title>
-    <style>
-      :root {
-        color-scheme: light;
-        font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-        line-height: 1.5;
+{% extends "invoice_classifier/base.html" %}
+
+{% block title %}Gestión de criterios de clasificación{% endblock %}
+
+{% block navbar %}
+  {% include "invoice_classifier/partials/navbar.html" with active_page="criteria" %}
+{% endblock %}
+
+{% block extra_head %}
+  {{ block.super }}
+  <style>
+    .criteria-page h1 {
+      margin-top: 0;
+      font-size: 2rem;
+    }
+
+    .criteria-page p {
+      max-width: 720px;
+    }
+
+    .criteria-page .messages {
+      list-style: none;
+      padding: 0;
+      margin: 1rem 0;
+    }
+
+    .criteria-page .messages li {
+      background: #ecfdf5;
+      border: 1px solid #34d399;
+      color: #065f46;
+      padding: 0.75rem 1rem;
+      border-radius: 0.75rem;
+      margin-bottom: 0.5rem;
+    }
+
+    .criteria-page .panels {
+      display: grid;
+      gap: 1.5rem;
+      grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+    }
+
+    .criteria-page .panel {
+      background: #ffffff;
+      border-radius: 1rem;
+      padding: 1.5rem;
+      box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+    }
+
+    .criteria-page form {
+      display: grid;
+      gap: 1rem;
+    }
+
+    .criteria-page label {
+      font-weight: 600;
+      display: block;
+      margin-bottom: 0.35rem;
+    }
+
+    .criteria-page input[type="text"],
+    .criteria-page textarea,
+    .criteria-page input[type="number"] {
+      width: 100%;
+      padding: 0.6rem 0.75rem;
+      border-radius: 0.5rem;
+      border: 1px solid #d4d4d8;
+      font-size: 0.95rem;
+      box-sizing: border-box;
+    }
+
+    .criteria-page textarea {
+      resize: vertical;
+    }
+
+    .criteria-page .helptext {
+      font-size: 0.8rem;
+      color: #52525b;
+    }
+
+    .criteria-page .errorlist {
+      margin: 0.25rem 0 0;
+      padding-left: 1.1rem;
+      color: #b91c1c;
+      font-size: 0.85rem;
+    }
+
+    .criteria-page button {
+      justify-self: start;
+      background: #2563eb;
+      color: #ffffff;
+      border: none;
+      border-radius: 0.5rem;
+      padding: 0.6rem 1.25rem;
+      font-size: 0.95rem;
+      cursor: pointer;
+      transition: background 0.2s ease;
+    }
+
+    .criteria-page button:hover {
+      background: #1d4ed8;
+    }
+
+    .criteria-page .criteria-list {
+      margin-top: 1.5rem;
+    }
+
+    .criteria-page .criteria-list ul {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+      display: grid;
+      gap: 0.75rem;
+    }
+
+    .criteria-page .criteria-item {
+      border: 1px solid #e4e4e7;
+      border-radius: 0.75rem;
+      padding: 0.75rem 1rem;
+      background: #fafafa;
+    }
+
+    .criteria-page .criteria-item strong {
+      display: block;
+      font-size: 1rem;
+      margin-bottom: 0.2rem;
+    }
+
+    .criteria-page .criteria-item a {
+      color: #2563eb;
+      text-decoration: none;
+      font-weight: 600;
+    }
+
+    .criteria-page .transactions {
+      margin-top: 2rem;
+    }
+
+    .criteria-page .transaction-list {
+      background: #ffffff;
+      border-radius: 1rem;
+      padding: 1rem;
+      box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+      max-height: 420px;
+      overflow-y: auto;
+    }
+
+    .criteria-page table {
+      width: 100%;
+      border-collapse: collapse;
+    }
+
+    .criteria-page th,
+    .criteria-page td {
+      text-align: left;
+      padding: 0.5rem 0.75rem;
+      border-bottom: 1px solid #e4e4e7;
+      font-size: 0.9rem;
+    }
+
+    .criteria-page th {
+      position: sticky;
+      top: 0;
+      background: #ffffff;
+      z-index: 1;
+    }
+
+    .criteria-page tr:last-child td {
+      border-bottom: none;
+    }
+
+    @media (max-width: 720px) {
+      .criteria-page {
+        padding: 0 0.5rem;
       }
 
-      body {
-        margin: 0;
-        background: #f4f4f5;
-        padding: 2rem;
+      .criteria-page .transaction-list {
+        max-height: 320px;
       }
+    }
+  </style>
+{% endblock %}
 
-      main {
-        max-width: 1200px;
-        margin: 0 auto;
-      }
+{% block content %}
+  <div class="criteria-page">
+    <h1>Gestión de criterios de clasificación</h1>
+    <p>
+      Crea reglas basadas en conceptos y rangos de importes. Cada vez que guardes un
+      criterio se revisarán los movimientos sin clasificar para aplicar la etiqueta
+      correspondiente de forma automática.
+    </p>
 
-      h1 {
-        margin-top: 0;
-        font-size: 2rem;
-      }
+    {% if messages %}
+      <ul class="messages">
+        {% for message in messages %}
+          <li>{{ message }}</li>
+        {% endfor %}
+      </ul>
+    {% endif %}
 
-      .messages {
-        list-style: none;
-        padding: 0;
-        margin: 1rem 0;
-      }
+    <div class="panels">
+      <section class="panel">
+        <h2>Nuevo criterio</h2>
+        <form method="post">
+          {% csrf_token %}
+          <input type="hidden" name="mode" value="create" />
+          {{ create_form.non_field_errors }}
 
-      .messages li {
-        background: #ecfdf5;
-        border: 1px solid #34d399;
-        color: #065f46;
-        padding: 0.75rem 1rem;
-        border-radius: 0.75rem;
-        margin-bottom: 0.5rem;
-      }
-
-      .panels {
-        display: grid;
-        gap: 1.5rem;
-        grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
-      }
-
-      .panel {
-        background: #ffffff;
-        border-radius: 1rem;
-        padding: 1.5rem;
-        box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
-      }
-
-      form {
-        display: grid;
-        gap: 1rem;
-      }
-
-      label {
-        font-weight: 600;
-        display: block;
-        margin-bottom: 0.35rem;
-      }
-
-      input[type="text"],
-      textarea,
-      input[type="number"] {
-        width: 100%;
-        padding: 0.6rem 0.75rem;
-        border-radius: 0.5rem;
-        border: 1px solid #d4d4d8;
-        font-size: 0.95rem;
-        box-sizing: border-box;
-      }
-
-      textarea {
-        resize: vertical;
-      }
-
-      .helptext {
-        font-size: 0.8rem;
-        color: #52525b;
-      }
-
-      .errorlist {
-        margin: 0.25rem 0 0;
-        padding-left: 1.1rem;
-        color: #b91c1c;
-        font-size: 0.85rem;
-      }
-
-      button {
-        justify-self: start;
-        background: #2563eb;
-        color: #ffffff;
-        border: none;
-        border-radius: 0.5rem;
-        padding: 0.6rem 1.25rem;
-        font-size: 0.95rem;
-        cursor: pointer;
-        transition: background 0.2s ease;
-      }
-
-      button:hover {
-        background: #1d4ed8;
-      }
-
-      .criteria-list {
-        margin-top: 1.5rem;
-      }
-
-      .criteria-list ul {
-        list-style: none;
-        padding: 0;
-        margin: 0;
-        display: grid;
-        gap: 0.75rem;
-      }
-
-      .criteria-item {
-        border: 1px solid #e4e4e7;
-        border-radius: 0.75rem;
-        padding: 0.75rem 1rem;
-        background: #fafafa;
-      }
-
-      .criteria-item strong {
-        display: block;
-        font-size: 1rem;
-        margin-bottom: 0.2rem;
-      }
-
-      .criteria-item a {
-        color: #2563eb;
-        text-decoration: none;
-        font-weight: 600;
-      }
-
-      .transactions {
-        margin-top: 2rem;
-      }
-
-      .transaction-list {
-        background: #ffffff;
-        border-radius: 1rem;
-        padding: 1rem;
-        box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
-        max-height: 420px;
-        overflow-y: auto;
-      }
-
-      table {
-        width: 100%;
-        border-collapse: collapse;
-      }
-
-      th,
-      td {
-        text-align: left;
-        padding: 0.5rem 0.75rem;
-        border-bottom: 1px solid #e4e4e7;
-        font-size: 0.9rem;
-      }
-
-      th {
-        position: sticky;
-        top: 0;
-        background: #ffffff;
-        z-index: 1;
-      }
-
-      tr:last-child td {
-        border-bottom: none;
-      }
-
-      @media (max-width: 720px) {
-        body {
-          padding: 1rem;
-        }
-
-        .transaction-list {
-          max-height: 320px;
-        }
-      }
-    </style>
-  </head>
-  <body>
-    <main>
-      <h1>Gestión de criterios de clasificación</h1>
-      <p>
-        Crea reglas basadas en conceptos y rangos de importes. Cada vez que guardes un
-        criterio se revisarán los movimientos sin clasificar para aplicar la etiqueta
-        correspondiente de forma automática.
-      </p>
-
-      {% if messages %}
-        <ul class="messages">
-          {% for message in messages %}
-            <li>{{ message }}</li>
+          {% for field in create_form %}
+            <div>
+              <label for="{{ field.id_for_label }}">{{ field.label }}</label>
+              {{ field }}
+              {% if field.help_text %}
+                <p class="helptext">{{ field.help_text }}</p>
+              {% endif %}
+              {{ field.errors }}
+            </div>
           {% endfor %}
-        </ul>
-      {% endif %}
 
-      <div class="panels">
-        <section class="panel">
-          <h2>Nuevo criterio</h2>
+          <button type="submit">Guardar criterio</button>
+        </form>
+      </section>
+
+      <section class="panel">
+        <h2>Editar criterio</h2>
+        {% if edit_form and edit_instance %}
           <form method="post">
             {% csrf_token %}
-            <input type="hidden" name="mode" value="create" />
-            {{ create_form.non_field_errors }}
+            <input type="hidden" name="mode" value="update" />
+            <input type="hidden" name="criterion_id" value="{{ edit_instance.pk }}" />
+            {{ edit_form.non_field_errors }}
 
-            {% for field in create_form %}
+            {% for field in edit_form %}
               <div>
                 <label for="{{ field.id_for_label }}">{{ field.label }}</label>
                 {{ field }}
@@ -225,101 +240,76 @@
               </div>
             {% endfor %}
 
-            <button type="submit">Guardar criterio</button>
+            <button type="submit">Actualizar criterio</button>
           </form>
-        </section>
+        {% else %}
+          <p>Selecciona un criterio de la lista inferior para editarlo.</p>
+        {% endif %}
 
-        <section class="panel">
-          <h2>Editar criterio</h2>
-          {% if edit_form and edit_instance %}
-            <form method="post">
-              {% csrf_token %}
-              <input type="hidden" name="mode" value="update" />
-              <input type="hidden" name="criterion_id" value="{{ edit_instance.pk }}" />
-              {{ edit_form.non_field_errors }}
-
-              {% for field in edit_form %}
+        <div class="criteria-list">
+          <h3>Listado de criterios</h3>
+          <ul>
+            {% for criterion in criteria_list %}
+              <li class="criteria-item">
+                <strong>{{ criterion.name }}</strong>
                 <div>
-                  <label for="{{ field.id_for_label }}">{{ field.label }}</label>
-                  {{ field }}
-                  {% if field.help_text %}
-                    <p class="helptext">{{ field.help_text }}</p>
-                  {% endif %}
-                  {{ field.errors }}
+                  <small>Slug: {{ criterion.slug }}</small>
                 </div>
-              {% endfor %}
-
-              <button type="submit">Actualizar criterio</button>
-            </form>
-          {% else %}
-            <p>Selecciona un criterio de la lista inferior para editarlo.</p>
-          {% endif %}
-
-          <div class="criteria-list">
-            <h3>Listado de criterios</h3>
-            <ul>
-              {% for criterion in criteria_list %}
-                <li class="criteria-item">
-                  <strong>{{ criterion.name }}</strong>
-                  <div>
-                    <small>Slug: {{ criterion.slug }}</small>
-                  </div>
-                  {% if criterion.description %}
-                    <p>{{ criterion.description }}</p>
-                  {% endif %}
-                  {% if criterion.concept_keywords %}
-                    <p>
-                      <strong>Palabras clave:</strong>
-                      {{ criterion.concept_keywords|join:", " }}
-                    </p>
-                  {% endif %}
+                {% if criterion.description %}
+                  <p>{{ criterion.description }}</p>
+                {% endif %}
+                {% if criterion.concept_keywords %}
                   <p>
-                    {% if criterion.min_amount %}
-                      Mín: {{ criterion.min_amount }}
-                    {% endif %}
-                    {% if criterion.max_amount %}
-                      Máx: {{ criterion.max_amount }}
-                    {% endif %}
+                    <strong>Palabras clave:</strong>
+                    {{ criterion.concept_keywords|join:", " }}
                   </p>
-                  <a href="?edit={{ criterion.pk }}">Editar</a>
-                </li>
-              {% empty %}
-                <li>No hay criterios definidos todavía.</li>
-              {% endfor %}
-            </ul>
-          </div>
-        </section>
-      </div>
-
-      <section class="transactions">
-        <h2>Movimientos sin clasificar ({{ unclassified_count }})</h2>
-        <div class="transaction-list">
-          {% if unclassified_count %}
-            <table>
-              <thead>
-                <tr>
-                  <th>Fecha</th>
-                  <th>Concepto</th>
-                  <th>Importe</th>
-                  <th>Importación</th>
-                </tr>
-              </thead>
-              <tbody>
-                {% for transaction in unclassified_transactions %}
-                  <tr>
-                    <td>{{ transaction.booking_date|date:"d/m/Y" }}</td>
-                    <td>{{ transaction.concept }}</td>
-                    <td>{{ transaction.amount }}</td>
-                    <td>{{ transaction.statement.source_name }}</td>
-                  </tr>
-                {% endfor %}
-              </tbody>
-            </table>
-          {% else %}
-            <p>No hay movimientos pendientes de clasificar.</p>
-          {% endif %}
+                {% endif %}
+                <p>
+                  {% if criterion.min_amount %}
+                    Mín: {{ criterion.min_amount }}
+                  {% endif %}
+                  {% if criterion.max_amount %}
+                    Máx: {{ criterion.max_amount }}
+                  {% endif %}
+                </p>
+                <a href="?edit={{ criterion.pk }}">Editar</a>
+              </li>
+            {% empty %}
+              <li>No hay criterios definidos todavía.</li>
+            {% endfor %}
+          </ul>
         </div>
       </section>
-    </main>
-  </body>
-</html>
+    </div>
+
+    <section class="transactions">
+      <h2>Movimientos sin clasificar ({{ unclassified_count }})</h2>
+      <div class="transaction-list">
+        {% if unclassified_count %}
+          <table>
+            <thead>
+              <tr>
+                <th>Fecha</th>
+                <th>Concepto</th>
+                <th>Importe</th>
+                <th>Importación</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for transaction in unclassified_transactions %}
+                <tr>
+                  <td>{{ transaction.booking_date|date:"d/m/Y" }}</td>
+                  <td>{{ transaction.concept }}</td>
+                  <td>{{ transaction.amount }}</td>
+                  <td>{{ transaction.statement.source_name }}</td>
+                </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        {% else %}
+          <p>No hay movimientos pendientes de clasificar.</p>
+        {% endif %}
+      </div>
+    </section>
+  </div>
+{% endblock %}

--- a/invoice_classifier/templates/invoice_classifier/partials/navbar.html
+++ b/invoice_classifier/templates/invoice_classifier/partials/navbar.html
@@ -1,0 +1,89 @@
+<nav class="top-nav">
+  <div class="top-nav__inner">
+    <a class="top-nav__brand" href="{% url 'index' %}">Bank Informer</a>
+    <ul class="top-nav__links">
+      <li>
+        <a href="{% url 'index' %}" class="{% if active_page == 'index' %}is-active{% endif %}">
+          Inicio
+        </a>
+      </li>
+      <li>
+        <a href="{% url 'manage_classification_criteria' %}" class="{% if active_page == 'criteria' %}is-active{% endif %}">
+          Criterios
+        </a>
+      </li>
+      <li>
+        <a href="{% url 'debug_sql_console' %}" class="{% if active_page == 'sql' %}is-active{% endif %}">
+          SQL
+        </a>
+      </li>
+      <li>
+        <a href="{% url 'admin:index' %}" class="{% if active_page == 'admin' %}is-active{% endif %}">
+          Admin
+        </a>
+      </li>
+    </ul>
+  </div>
+</nav>
+<style>
+  .top-nav {
+    background: #1f2937;
+    color: #f8fafc;
+    box-shadow: 0 2px 12px rgba(15, 23, 42, 0.16);
+  }
+
+  .top-nav__inner {
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: 1rem 1.5rem;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1.5rem;
+  }
+
+  .top-nav__brand {
+    font-weight: 700;
+    letter-spacing: -0.01em;
+    text-decoration: none;
+    color: inherit;
+  }
+
+  .top-nav__links {
+    list-style: none;
+    display: flex;
+    gap: 0.75rem;
+    margin: 0;
+    padding: 0;
+  }
+
+  .top-nav__links a {
+    text-decoration: none;
+    color: inherit;
+    padding: 0.35rem 0.85rem;
+    border-radius: 999px;
+    font-weight: 500;
+    transition: background 0.2s ease, color 0.2s ease;
+  }
+
+  .top-nav__links a:hover {
+    background: rgba(148, 163, 184, 0.2);
+  }
+
+  .top-nav__links a.is-active {
+    background: #3b82f6;
+    color: white;
+  }
+
+  @media (max-width: 640px) {
+    .top-nav__inner {
+      flex-direction: column;
+      align-items: flex-start;
+    }
+
+    .top-nav__links {
+      flex-wrap: wrap;
+      gap: 0.5rem;
+    }
+  }
+</style>


### PR DESCRIPTION
## Summary
- add a shared base layout template with optional body and content classes
- introduce a reusable navigation partial for navigating between importer, criteria, SQL console, and admin
- update index, criteria management, and SQL debug templates to extend the base and adjust styling
- tweak importer page styles to work with the shared layout

## Testing
- python manage.py check *(fails: Django not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d81025fcc4832f8608fb9967f1b2ae