### PR TITLE
Add interactive spending visualizer page

### DIFF
--- a/invoice_classifier/static/invoice_classifier/visualizer.css
+++ b/invoice_classifier/static/invoice_classifier/visualizer.css
@@ -119,27 +119,27 @@
   color: #0f172a;
 }
 
-.criteria-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-  gap: 0.75rem;
+.criteria-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
 }
 
-.criteria-item {
-  background: #f8fafc;
-  border: 1px solid #cbd5f5;
-  border-radius: 12px;
-  padding: 0.6rem 0.75rem;
+.criteria-list__item {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.65rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: 10px;
+  border: 1px solid #cbd5f5;
+  background: #f8fafc;
   font-weight: 500;
   cursor: pointer;
 }
 
-.criteria-item input {
-  width: 1.1rem;
-  height: 1.1rem;
+.criteria-list__item input {
+  width: 1.05rem;
+  height: 1.05rem;
 }
 
 .controls__submit {
@@ -165,6 +165,21 @@
   box-shadow: 0 18px 50px rgba(15, 23, 42, 0.1);
 }
 
+.visualizer__board {
+  display: flex;
+  gap: 1.5rem;
+  align-items: stretch;
+}
+
+.controls__group--criteria {
+  flex: 0 0 30%;
+  max-width: 340px;
+}
+
+.visualizer__chart {
+  flex: 1 1 70%;
+}
+
 .chart-card__inner {
   position: relative;
   width: 100%;
@@ -185,5 +200,21 @@
 
   .field {
     min-width: unset;
+  }
+}
+
+@media (max-width: 900px) {
+  .visualizer__board {
+    flex-direction: column;
+  }
+
+  .controls__group--criteria,
+  .visualizer__chart {
+    flex: 1 1 auto;
+    max-width: none;
+  }
+
+  .visualizer__chart {
+    display: block;
   }
 }

--- a/invoice_classifier/static/invoice_classifier/visualizer.css
+++ b/invoice_classifier/static/invoice_classifier/visualizer.css
@@ -1,0 +1,189 @@
+.visualizer {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.visualizer__header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.visualizer__header h1 {
+  margin: 0;
+  font-size: 1.75rem;
+}
+
+.visualizer__subtitle {
+  margin: 0.35rem 0 0;
+  color: #475569;
+  max-width: 40ch;
+}
+
+.visualizer__period {
+  margin: 0;
+  font-weight: 500;
+  color: #1d4ed8;
+}
+
+.controls {
+  background: white;
+  border-radius: 16px;
+  padding: 1.5rem;
+  box-shadow: 0 12px 40px rgba(15, 23, 42, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.controls__group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem 1.5rem;
+}
+
+.controls__group--period {
+  align-items: flex-end;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  min-width: 140px;
+}
+
+.field label,
+.field span {
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.field select {
+  padding: 0.55rem 0.75rem;
+  border-radius: 8px;
+  border: 1px solid #cbd5f5;
+  background: #f8fafc;
+  font: inherit;
+}
+
+.field--toggle {
+  gap: 0.5rem;
+}
+
+.toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: #e2e8f0;
+  border-radius: 999px;
+  padding: 0.25rem;
+}
+
+.toggle label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  cursor: pointer;
+  font-weight: 600;
+  color: #475569;
+}
+
+.toggle input {
+  display: none;
+}
+
+.toggle input:checked + span {
+  background: #1d4ed8;
+  color: white;
+  padding: 0.25rem 0.65rem;
+  border-radius: 999px;
+}
+
+.controls__group--criteria {
+  border: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.controls__group--criteria legend {
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.criteria-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 0.75rem;
+}
+
+.criteria-item {
+  background: #f8fafc;
+  border: 1px solid #cbd5f5;
+  border-radius: 12px;
+  padding: 0.6rem 0.75rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.criteria-item input {
+  width: 1.1rem;
+  height: 1.1rem;
+}
+
+.controls__submit {
+  align-self: flex-start;
+  padding: 0.75rem 1.5rem;
+  border-radius: 999px;
+  border: none;
+  background: #2563eb;
+  color: white;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 0 10px 24px rgba(37, 99, 235, 0.25);
+}
+
+.controls__submit:hover {
+  background: #1d4ed8;
+}
+
+.chart-card {
+  background: white;
+  border-radius: 18px;
+  padding: 1.5rem;
+  box-shadow: 0 18px 50px rgba(15, 23, 42, 0.1);
+}
+
+.chart-card__inner {
+  position: relative;
+  width: 100%;
+  min-height: 320px;
+}
+
+.chart-card__empty {
+  margin: 0;
+  text-align: center;
+  color: #475569;
+}
+
+@media (max-width: 640px) {
+  .controls__group--period {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .field {
+    min-width: unset;
+  }
+}

--- a/invoice_classifier/static/invoice_classifier/visualizer.js
+++ b/invoice_classifier/static/invoice_classifier/visualizer.js
@@ -18,20 +18,21 @@
     return colors;
   }
 
-  function renderChart(container) {
-    if (!container) {
-      return;
+  function readChartData() {
+    const script = document.getElementById('visualizer-chart-data');
+    if (!script) {
+      return [];
     }
 
-    const rawData = container.dataset.chart || '[]';
-    let parsed;
     try {
-      parsed = JSON.parse(rawData);
+      return JSON.parse(script.textContent || '[]');
     } catch (error) {
-      parsed = [];
+      return [];
     }
+  }
 
-    if (!Array.isArray(parsed) || parsed.length === 0) {
+  function renderChart(container, parsed) {
+    if (!container || !Array.isArray(parsed) || parsed.length === 0) {
       return;
     }
 
@@ -41,6 +42,10 @@
 
     const ctx = container.querySelector('#spending-chart');
     if (!ctx) {
+      return;
+    }
+
+    if (typeof window.Chart !== 'function') {
       return;
     }
 
@@ -104,6 +109,7 @@
 
   document.addEventListener('DOMContentLoaded', () => {
     const container = document.querySelector('.chart-card__inner');
-    renderChart(container);
+    const chartData = readChartData();
+    renderChart(container, chartData);
   });
 })();

--- a/invoice_classifier/static/invoice_classifier/visualizer.js
+++ b/invoice_classifier/static/invoice_classifier/visualizer.js
@@ -1,0 +1,109 @@
+(function () {
+  function buildPalette(size) {
+    const baseColors = [
+      '#2563eb',
+      '#14b8a6',
+      '#f97316',
+      '#f43f5e',
+      '#a855f7',
+      '#22c55e',
+      '#0ea5e9',
+      '#facc15',
+      '#64748b',
+    ];
+    const colors = [];
+    for (let i = 0; i < size; i += 1) {
+      colors.push(baseColors[i % baseColors.length]);
+    }
+    return colors;
+  }
+
+  function renderChart(container) {
+    if (!container) {
+      return;
+    }
+
+    const rawData = container.dataset.chart || '[]';
+    let parsed;
+    try {
+      parsed = JSON.parse(rawData);
+    } catch (error) {
+      parsed = [];
+    }
+
+    if (!Array.isArray(parsed) || parsed.length === 0) {
+      return;
+    }
+
+    const labels = parsed.map((item) => item.name);
+    const data = parsed.map((item) => item.total);
+    const colors = buildPalette(parsed.length);
+
+    const ctx = container.querySelector('#spending-chart');
+    if (!ctx) {
+      return;
+    }
+
+    new window.Chart(ctx, {
+      type: 'bar',
+      data: {
+        labels,
+        datasets: [
+          {
+            label: 'Gasto',
+            data,
+            backgroundColor: colors,
+            borderRadius: 8,
+          },
+        ],
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        scales: {
+          y: {
+            beginAtZero: true,
+            ticks: {
+              callback(value) {
+                return `${value.toLocaleString('es-ES', {
+                  style: 'currency',
+                  currency: 'EUR',
+                  maximumFractionDigits: 0,
+                })}`;
+              },
+            },
+            grid: {
+              color: 'rgba(148, 163, 184, 0.25)',
+            },
+          },
+          x: {
+            grid: {
+              display: false,
+            },
+          },
+        },
+        plugins: {
+          legend: {
+            display: false,
+          },
+          tooltip: {
+            callbacks: {
+              label(context) {
+                const amount = context.parsed.y || 0;
+                return `Gasto: ${amount.toLocaleString('es-ES', {
+                  style: 'currency',
+                  currency: 'EUR',
+                })}`;
+              },
+            },
+          },
+        },
+      },
+    });
+  }
+
+  document.addEventListener('DOMContentLoaded', () => {
+    const container = document.querySelector('.chart-card__inner');
+    renderChart(container);
+  });
+})();

--- a/invoice_classifier/templates/invoice_classifier/partials/navbar.html
+++ b/invoice_classifier/templates/invoice_classifier/partials/navbar.html
@@ -13,6 +13,11 @@
         </a>
       </li>
       <li>
+        <a href="{% url 'visualizer' %}" class="{% if active_page == 'visualizer' %}is-active{% endif %}">
+          Visualizador
+        </a>
+      </li>
+      <li>
         <a href="{% url 'debug_sql_console' %}" class="{% if active_page == 'sql' %}is-active{% endif %}">
           SQL
         </a>

--- a/invoice_classifier/templates/invoice_classifier/visualizer.html
+++ b/invoice_classifier/templates/invoice_classifier/visualizer.html
@@ -80,7 +80,8 @@
 
         <section class="chart-card visualizer__chart">
           {% if chart_entries %}
-            <div class="chart-card__inner" data-chart='{{ chart_payload|escapejs }}'>
+            {{ chart_entries|json_script:"visualizer-chart-data" }}
+            <div class="chart-card__inner">
               <canvas id="spending-chart" height="120"></canvas>
             </div>
           {% else %}

--- a/invoice_classifier/templates/invoice_classifier/visualizer.html
+++ b/invoice_classifier/templates/invoice_classifier/visualizer.html
@@ -1,0 +1,98 @@
+{% extends "invoice_classifier/base.html" %}
+{% load static %}
+
+{% block title %}Visualizador de gastos{% endblock %}
+
+{% block navbar %}
+  {% include "invoice_classifier/partials/navbar.html" with active_page="visualizer" %}
+{% endblock %}
+
+{% block extra_head %}
+  {{ block.super }}
+  <link rel="stylesheet" href="{% static 'invoice_classifier/visualizer.css' %}" />
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.4/dist/chart.umd.min.js" defer></script>
+{% endblock %}
+
+{% block content %}
+  <section class="visualizer">
+    <header class="visualizer__header">
+      <div>
+        <h1>Visualizador de gastos</h1>
+        <p class="visualizer__subtitle">Filtra por periodo y criterios para ver cuánto has gastado.</p>
+      </div>
+      <p class="visualizer__period">Periodo seleccionado: <strong>{{ period_label }}</strong></p>
+    </header>
+
+    <form class="controls" method="get">
+      <div class="controls__group controls__group--period">
+        <div class="field">
+          <label for="month-select">Mes</label>
+          <select id="month-select" name="month" {% if view_mode == 'yearly' %}disabled{% endif %}>
+            {% for value, label in month_choices %}
+              <option value="{{ value }}" {% if value == selected_month %}selected{% endif %}>
+                {{ label }}
+              </option>
+            {% endfor %}
+          </select>
+        </div>
+        <div class="field">
+          <label for="year-select">Año</label>
+          <select id="year-select" name="year">
+            {% for year in available_years %}
+              <option value="{{ year }}" {% if year == selected_year %}selected{% endif %}>{{ year }}</option>
+            {% endfor %}
+          </select>
+        </div>
+        <div class="field field--toggle">
+          <span>Modo</span>
+          <div class="toggle">
+            <label>
+              <input type="radio" name="mode" value="monthly" {% if view_mode == 'monthly' %}checked{% endif %} />
+              <span>Mensual</span>
+            </label>
+            <label>
+              <input type="radio" name="mode" value="yearly" {% if view_mode == 'yearly' %}checked{% endif %} />
+              <span>Anual</span>
+            </label>
+          </div>
+        </div>
+      </div>
+
+      <fieldset class="controls__group controls__group--criteria">
+        <legend>Selecciona criterios</legend>
+        <div class="criteria-grid">
+          {% for criterion in criteria_list %}
+            <label class="criteria-item">
+              <input
+                type="checkbox"
+                name="criteria"
+                value="{{ criterion.slug }}"
+                {% if criterion.slug in selected_criteria_slugs %}checked{% endif %}
+              />
+              <span>{{ criterion.name }}</span>
+            </label>
+          {% empty %}
+            <p>No hay criterios definidos todavía.</p>
+          {% endfor %}
+        </div>
+      </fieldset>
+
+      <button type="submit" class="controls__submit">Actualizar visualización</button>
+    </form>
+
+    <section class="chart-card">
+      {% if chart_entries %}
+        <div class="chart-card__inner" data-chart='{{ chart_payload|escapejs }}'>
+          <canvas id="spending-chart" height="120"></canvas>
+        </div>
+      {% else %}
+        <p class="chart-card__empty">No hay movimientos que coincidan con los filtros seleccionados.</p>
+      {% endif %}
+    </section>
+  </section>
+{% endblock %}
+
+{% block extra_scripts %}
+  {{ block.super }}
+  <script src="{% static 'invoice_classifier/visualizer.js' %}" defer></script>
+{% endblock %}

--- a/invoice_classifier/templates/invoice_classifier/visualizer.html
+++ b/invoice_classifier/templates/invoice_classifier/visualizer.html
@@ -58,37 +58,39 @@
         </div>
       </div>
 
-      <fieldset class="controls__group controls__group--criteria">
-        <legend>Selecciona criterios</legend>
-        <div class="criteria-grid">
-          {% for criterion in criteria_list %}
-            <label class="criteria-item">
-              <input
-                type="checkbox"
-                name="criteria"
-                value="{{ criterion.slug }}"
-                {% if criterion.slug in selected_criteria_slugs %}checked{% endif %}
-              />
-              <span>{{ criterion.name }}</span>
-            </label>
-          {% empty %}
-            <p>No hay criterios definidos todavía.</p>
-          {% endfor %}
-        </div>
-      </fieldset>
+      <div class="visualizer__board">
+        <fieldset class="controls__group controls__group--criteria">
+          <legend>Selecciona criterios</legend>
+          <div class="criteria-list">
+            {% for criterion in criteria_list %}
+              <label class="criteria-list__item">
+                <input
+                  type="checkbox"
+                  name="criteria"
+                  value="{{ criterion.slug }}"
+                  {% if criterion.slug in selected_criteria_slugs %}checked{% endif %}
+                />
+                <span>{{ criterion.name }}</span>
+              </label>
+            {% empty %}
+              <p>No hay criterios definidos todavía.</p>
+            {% endfor %}
+          </div>
+        </fieldset>
+
+        <section class="chart-card visualizer__chart">
+          {% if chart_entries %}
+            <div class="chart-card__inner" data-chart='{{ chart_payload|escapejs }}'>
+              <canvas id="spending-chart" height="120"></canvas>
+            </div>
+          {% else %}
+            <p class="chart-card__empty">No hay movimientos que coincidan con los filtros seleccionados.</p>
+          {% endif %}
+        </section>
+      </div>
 
       <button type="submit" class="controls__submit">Actualizar visualización</button>
     </form>
-
-    <section class="chart-card">
-      {% if chart_entries %}
-        <div class="chart-card__inner" data-chart='{{ chart_payload|escapejs }}'>
-          <canvas id="spending-chart" height="120"></canvas>
-        </div>
-      {% else %}
-        <p class="chart-card__empty">No hay movimientos que coincidan con los filtros seleccionados.</p>
-      {% endif %}
-    </section>
   </section>
 {% endblock %}
 

--- a/invoice_classifier/urls.py
+++ b/invoice_classifier/urls.py
@@ -4,6 +4,7 @@ from . import views
 
 urlpatterns = [
     path("", views.index, name="index"),
+    path("visualizador/", views.visualizer, name="visualizer"),
     path("api/imports/", views.upload_statement, name="upload_statement"),
     path("debug/sql/", views.debug_sql_console, name="debug_sql_console"),
     path(

--- a/invoice_classifier/views.py
+++ b/invoice_classifier/views.py
@@ -4,21 +4,31 @@ from __future__ import annotations
 
 import csv
 import io
-from datetime import datetime
+import json
+from calendar import monthrange
+from datetime import date, datetime, timedelta
 from decimal import Decimal, InvalidOperation
 
 from django.contrib import messages
 from django.core.files.base import ContentFile
+from django.core.serializers.json import DjangoJSONEncoder
 from django.db import connection, transaction
+from django.db.models import Sum
 from django.db.utils import DatabaseError
 from django.http import HttpRequest, HttpResponse, JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from django.views.decorators.csrf import ensure_csrf_cookie
 from django.views.decorators.http import require_http_methods
+from django.utils import timezone
 
 from .forms import ClassificationCriterionForm
-from .models import BankTransaction, ClassificationCriterion, StatementImport
+from .models import (
+    BankTransaction,
+    ClassificationCriterion,
+    StatementImport,
+    TransactionClassification,
+)
 
 
 @ensure_csrf_cookie
@@ -26,6 +36,127 @@ def index(request: HttpRequest) -> HttpResponse:
     """Render the Vue-powered index page."""
 
     return render(request, "invoice_classifier/index.html")
+
+
+MONTH_NAMES_ES = [
+    "",
+    "Enero",
+    "Febrero",
+    "Marzo",
+    "Abril",
+    "Mayo",
+    "Junio",
+    "Julio",
+    "Agosto",
+    "Septiembre",
+    "Octubre",
+    "Noviembre",
+    "Diciembre",
+]
+
+
+@ensure_csrf_cookie
+def visualizer(request: HttpRequest) -> HttpResponse:
+    """Display aggregated spending per criterion using interactive controls."""
+
+    today = timezone.localdate()
+    view_mode = request.GET.get("mode", "monthly")
+    if view_mode not in {"monthly", "yearly"}:
+        view_mode = "monthly"
+
+    try:
+        selected_year = int(request.GET.get("year", today.year))
+    except (TypeError, ValueError):
+        selected_year = today.year
+
+    try:
+        selected_month = int(request.GET.get("month", today.month))
+    except (TypeError, ValueError):
+        selected_month = today.month
+
+    if not 1 <= selected_month <= 12:
+        selected_month = today.month
+
+    criteria_qs = ClassificationCriterion.objects.all().order_by("name")
+    available_criteria_slugs = list(criteria_qs.values_list("slug", flat=True))
+
+    requested_slugs = [slug for slug in request.GET.getlist("criteria") if slug]
+    if requested_slugs:
+        selected_criteria_slugs = [
+            slug for slug in requested_slugs if slug in available_criteria_slugs
+        ]
+    else:
+        selected_criteria_slugs = available_criteria_slugs.copy()
+
+    selected_criteria = list(
+        criteria_qs.filter(slug__in=selected_criteria_slugs).order_by("name")
+    )
+
+    if view_mode == "monthly":
+        period_start = date(selected_year, selected_month, 1)
+        _, days_in_month = monthrange(selected_year, selected_month)
+        period_end = period_start + timedelta(days=days_in_month)
+        period_label = f"{MONTH_NAMES_ES[period_start.month]} {period_start.year}"
+    else:
+        period_start = date(selected_year, 1, 1)
+        period_end = date(selected_year + 1, 1, 1)
+        period_label = f"{selected_year}"
+
+    classifications = TransactionClassification.objects.filter(
+        label__criterion__in=selected_criteria,
+        transaction__booking_date__gte=period_start,
+        transaction__booking_date__lt=period_end,
+        transaction__amount__lt=0,
+    )
+
+    aggregated_spending = (
+        classifications.values(
+            "label__criterion__name", "label__criterion__slug", "label__criterion_id"
+        )
+        .annotate(total_spent=Sum("transaction__amount"))
+        .order_by("label__criterion__name")
+    )
+
+    chart_entries: list[dict[str, object]] = []
+    for entry in aggregated_spending:
+        total_spent = entry.get("total_spent") or Decimal("0")
+        chart_entries.append(
+            {
+                "slug": entry["label__criterion__slug"],
+                "name": entry["label__criterion__name"],
+                "total": float(-total_spent),
+            }
+        )
+
+    chart_payload = json.dumps(chart_entries, cls=DjangoJSONEncoder)
+
+    available_years_qs = BankTransaction.objects.filter(booking_date__isnull=False).dates(
+        "booking_date", "year", order="ASC"
+    )
+    available_years = [dt.year for dt in available_years_qs]
+    if not available_years:
+        available_years = [today.year]
+
+    month_choices = [(index, MONTH_NAMES_ES[index]) for index in range(1, 13)]
+
+    context = {
+        "criteria_list": criteria_qs,
+        "selected_criteria_slugs": selected_criteria_slugs,
+        "view_mode": view_mode,
+        "selected_year": selected_year,
+        "selected_month": selected_month,
+        "period_label": period_label,
+        "chart_entries": chart_entries,
+        "chart_payload": chart_payload,
+        "available_years": available_years,
+        "month_choices": month_choices,
+    }
+
+    return render(
+        request,
+        "invoice_classifier/visualizer.html",
+        context,
+    )
 
 
 def _parse_decimal(value: str) -> Decimal:

--- a/invoice_classifier/views.py
+++ b/invoice_classifier/views.py
@@ -4,14 +4,12 @@ from __future__ import annotations
 
 import csv
 import io
-import json
 from calendar import monthrange
 from datetime import date, datetime, timedelta
 from decimal import Decimal, InvalidOperation
 
 from django.contrib import messages
 from django.core.files.base import ContentFile
-from django.core.serializers.json import DjangoJSONEncoder
 from django.db import connection, transaction
 from django.db.models import Sum
 from django.db.utils import DatabaseError
@@ -128,8 +126,6 @@ def visualizer(request: HttpRequest) -> HttpResponse:
             }
         )
 
-    chart_payload = json.dumps(chart_entries, cls=DjangoJSONEncoder)
-
     available_years_qs = BankTransaction.objects.filter(booking_date__isnull=False).dates(
         "booking_date", "year", order="ASC"
     )
@@ -147,7 +143,6 @@ def visualizer(request: HttpRequest) -> HttpResponse:
         "selected_month": selected_month,
         "period_label": period_label,
         "chart_entries": chart_entries,
-        "chart_payload": chart_payload,
         "available_years": available_years,
         "month_choices": month_choices,
     }


### PR DESCRIPTION
## Summary
- add a Visualizer view that aggregates spending per criterion with monthly/yearly filters
- create a new template, styles, and Chart.js-powered script for the interactive visualization
- expose the view via navigation and URL routing

## Testing
- python manage.py test *(fails: missing Django dependency in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d817d08660832f8dc88328cc9b470b