### PR TITLE
Swap index and visualizer views

### DIFF
--- a/invoice_classifier/templates/invoice_classifier/partials/navbar.html
+++ b/invoice_classifier/templates/invoice_classifier/partials/navbar.html
@@ -4,7 +4,7 @@
     <ul class="top-nav__links">
       <li>
         <a href="{% url 'index' %}" class="{% if active_page == 'index' %}is-active{% endif %}">
-          Inicio
+          Visualizador
         </a>
       </li>
       <li>
@@ -13,8 +13,8 @@
         </a>
       </li>
       <li>
-        <a href="{% url 'visualizer' %}" class="{% if active_page == 'visualizer' %}is-active{% endif %}">
-          Visualizador
+        <a href="{% url 'upload_csv' %}" class="{% if active_page == 'upload' %}is-active{% endif %}">
+          Upload CSV
         </a>
       </li>
       <li>

--- a/invoice_classifier/templates/invoice_classifier/upload_csv.html
+++ b/invoice_classifier/templates/invoice_classifier/upload_csv.html
@@ -1,7 +1,7 @@
 {% extends "invoice_classifier/base.html" %}
 {% load static %}
 
-{% block title %}Importador bancario{% endblock %}
+{% block title %}Upload CSV{% endblock %}
 
 {% block body_class %}index-body{% endblock %}
 
@@ -14,7 +14,7 @@
 {% endblock %}
 
 {% block navbar %}
-  {% include "invoice_classifier/partials/navbar.html" with active_page="index" %}
+  {% include "invoice_classifier/partials/navbar.html" with active_page="upload" %}
 {% endblock %}
 
 {% block content %}

--- a/invoice_classifier/templates/invoice_classifier/visualizer.html
+++ b/invoice_classifier/templates/invoice_classifier/visualizer.html
@@ -4,7 +4,7 @@
 {% block title %}Visualizador de gastos{% endblock %}
 
 {% block navbar %}
-  {% include "invoice_classifier/partials/navbar.html" with active_page="visualizer" %}
+  {% include "invoice_classifier/partials/navbar.html" with active_page="index" %}
 {% endblock %}
 
 {% block extra_head %}

--- a/invoice_classifier/urls.py
+++ b/invoice_classifier/urls.py
@@ -4,7 +4,8 @@ from . import views
 
 urlpatterns = [
     path("", views.index, name="index"),
-    path("visualizador/", views.visualizer, name="visualizer"),
+    path("visualizador/", views.visualizer, name="visualizer_legacy"),
+    path("upload-csv/", views.upload_csv, name="upload_csv"),
     path("api/imports/", views.upload_statement, name="upload_statement"),
     path("debug/sql/", views.debug_sql_console, name="debug_sql_console"),
     path(

--- a/invoice_classifier/views.py
+++ b/invoice_classifier/views.py
@@ -30,10 +30,10 @@ from .models import (
 
 
 @ensure_csrf_cookie
-def index(request: HttpRequest) -> HttpResponse:
-    """Render the Vue-powered index page."""
+def upload_csv(request: HttpRequest) -> HttpResponse:
+    """Render the CSV upload interface."""
 
-    return render(request, "invoice_classifier/index.html")
+    return render(request, "invoice_classifier/upload_csv.html")
 
 
 MONTH_NAMES_ES = [
@@ -54,7 +54,7 @@ MONTH_NAMES_ES = [
 
 
 @ensure_csrf_cookie
-def visualizer(request: HttpRequest) -> HttpResponse:
+def index(request: HttpRequest) -> HttpResponse:
     """Display aggregated spending per criterion using interactive controls."""
 
     today = timezone.localdate()
@@ -152,6 +152,13 @@ def visualizer(request: HttpRequest) -> HttpResponse:
         "invoice_classifier/visualizer.html",
         context,
     )
+
+
+@ensure_csrf_cookie
+def visualizer(request: HttpRequest) -> HttpResponse:
+    """Backward-compatible alias for the CSV upload page."""
+
+    return upload_csv(request)
 
 
 def _parse_decimal(value: str) -> Decimal:


### PR DESCRIPTION
## Summary
- make the visualizer page the new index view and expose the CSV uploader at /upload-csv/
- rename the legacy index template to upload_csv.html and update navigation links
- keep a legacy /visualizador/ route pointing to the uploader for backwards compatibility

## Testing
- `python manage.py test` *(fails: missing Django dependency in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d8283037a0832f8d16e6b4219ba4eb