### PR TITLE
Auto-refresh the visualizer when filters change

### DIFF
--- a/invoice_classifier/static/invoice_classifier/visualizer.css
+++ b/invoice_classifier/static/invoice_classifier/visualizer.css
@@ -20,7 +20,7 @@
 .visualizer__subtitle {
   margin: 0.35rem 0 0;
   color: #475569;
-  max-width: 40ch;
+  max-width: 60ch;
 }
 
 .visualizer__period {

--- a/invoice_classifier/static/invoice_classifier/visualizer.js
+++ b/invoice_classifier/static/invoice_classifier/visualizer.js
@@ -111,5 +111,53 @@
     const container = document.querySelector('.chart-card__inner');
     const chartData = readChartData();
     renderChart(container, chartData);
+
+    const form = document.querySelector('.controls');
+    if (!form) {
+      return;
+    }
+
+    const monthSelect = form.querySelector('#month-select');
+    const modeInputs = form.querySelectorAll('input[name="mode"]');
+    const criteriaInputs = form.querySelectorAll('input[name="criteria"]');
+    const yearSelect = form.querySelector('#year-select');
+
+    const submitForm = () => {
+      if (typeof form.requestSubmit === 'function') {
+        form.requestSubmit();
+      } else {
+        form.submit();
+      }
+    };
+
+    const updateMonthAvailability = () => {
+      const selectedMode = form.querySelector('input[name="mode"]:checked');
+      if (!monthSelect || !selectedMode) {
+        return;
+      }
+
+      monthSelect.disabled = selectedMode.value === 'yearly';
+    };
+
+    if (monthSelect) {
+      monthSelect.addEventListener('change', submitForm);
+    }
+
+    if (yearSelect) {
+      yearSelect.addEventListener('change', submitForm);
+    }
+
+    modeInputs.forEach((input) => {
+      input.addEventListener('change', () => {
+        updateMonthAvailability();
+        submitForm();
+      });
+    });
+
+    criteriaInputs.forEach((input) => {
+      input.addEventListener('change', submitForm);
+    });
+
+    updateMonthAvailability();
   });
 })();

--- a/invoice_classifier/templates/invoice_classifier/visualizer.html
+++ b/invoice_classifier/templates/invoice_classifier/visualizer.html
@@ -89,8 +89,6 @@
           {% endif %}
         </section>
       </div>
-
-      <button type="submit" class="controls__submit">Actualizar visualización</button>
     </form>
   </section>
 {% endblock %}


### PR DESCRIPTION
## Summary
- remove the manual refresh button from the visualizer form
- automatically submit the filters form when any selection changes and keep the month selector disabled in yearly mode

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d82b90547c832fa6c903290a2952de