### PR TITLE
Make visualizer bars interactive with transaction details

### DIFF
--- a/invoice_classifier/static/invoice_classifier/visualizer.css
+++ b/invoice_classifier/static/invoice_classifier/visualizer.css
@@ -192,6 +192,81 @@
   color: #475569;
 }
 
+.visualizer__details {
+  background: white;
+  border-radius: 18px;
+  padding: 1.5rem;
+  box-shadow: 0 18px 50px rgba(15, 23, 42, 0.1);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.visualizer__details[hidden] {
+  display: none;
+}
+
+.visualizer__details-title {
+  margin: 0;
+  font-size: 1.25rem;
+  color: #0f172a;
+}
+
+.visualizer__details-title span {
+  color: #1d4ed8;
+}
+
+.visualizer__details-table-wrapper {
+  overflow-x: auto;
+}
+
+.visualizer__details-table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 420px;
+}
+
+.visualizer__details-table th,
+.visualizer__details-table td {
+  padding: 0.75rem 1rem;
+  text-align: left;
+  border-bottom: 1px solid #e2e8f0;
+  color: #0f172a;
+}
+
+.visualizer__details-table tbody tr:hover {
+  background: #f8fafc;
+}
+
+.visualizer__details-amount {
+  text-align: right;
+}
+
+.visualizer__sort-button {
+  appearance: none;
+  border: none;
+  background: transparent;
+  font: inherit;
+  font-weight: 600;
+  color: #0f172a;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  cursor: pointer;
+  padding: 0;
+}
+
+.visualizer__sort-button::after {
+  content: attr(data-sort-indicator);
+  font-size: 0.75em;
+  color: #64748b;
+}
+
+.visualizer__sort-button:focus-visible {
+  outline: 2px solid #2563eb;
+  outline-offset: 2px;
+}
+
 @media (max-width: 640px) {
   .controls__group--period {
     flex-direction: column;

--- a/invoice_classifier/static/invoice_classifier/visualizer.js
+++ b/invoice_classifier/static/invoice_classifier/visualizer.js
@@ -31,7 +31,32 @@
     }
   }
 
-  function renderChart(container, parsed) {
+  function formatCurrency(value) {
+    const amount = Number.isFinite(value) ? value : 0;
+    return amount.toLocaleString('es-ES', {
+      style: 'currency',
+      currency: 'EUR',
+    });
+  }
+
+  function formatDate(value) {
+    if (!value) {
+      return '';
+    }
+
+    const parsedDate = new Date(value);
+    if (Number.isNaN(parsedDate.getTime())) {
+      return value;
+    }
+
+    return parsedDate.toLocaleDateString('es-ES', {
+      year: 'numeric',
+      month: 'short',
+      day: '2-digit',
+    });
+  }
+
+  function renderChart(container, parsed, onBarClick) {
     if (!container || !Array.isArray(parsed) || parsed.length === 0) {
       return;
     }
@@ -49,7 +74,7 @@
       return;
     }
 
-    new window.Chart(ctx, {
+    const chart = new window.Chart(ctx, {
       type: 'bar',
       data: {
         labels,
@@ -104,13 +129,198 @@
           },
         },
       },
+      onHover(event, elements) {
+        const canvas = event && event.chart ? event.chart.canvas : null;
+        if (!canvas) {
+          return;
+        }
+
+        canvas.style.cursor = elements.length ? 'pointer' : 'default';
+      },
+      onClick(_event, elements) {
+        if (!elements || elements.length === 0 || typeof onBarClick !== 'function') {
+          return;
+        }
+
+        const index = elements[0].index;
+        if (typeof index !== 'number') {
+          return;
+        }
+
+        const entry = parsed[index];
+        if (!entry) {
+          return;
+        }
+
+        onBarClick(entry, index);
+      },
     });
+
+    return chart;
+  }
+
+  function initDetailsSection() {
+    const section = document.querySelector('[data-details]');
+    if (!section) {
+      return () => {};
+    }
+
+    const titleTarget = section.querySelector('[data-details-name]');
+    const tbody = section.querySelector('[data-details-body]');
+    const headerButtons = Array.from(
+      section.querySelectorAll('[data-sort-key]')
+    );
+
+    let currentTransactions = [];
+    let currentSort = { key: 'date', direction: 'desc' };
+
+    const sortComparators = {
+      name(a, b) {
+        return (a.name || '').localeCompare(b.name || '', 'es', {
+          sensitivity: 'base',
+        });
+      },
+      date(a, b) {
+        const left = new Date(a.date || '').getTime();
+        const right = new Date(b.date || '').getTime();
+        if (Number.isNaN(left) && Number.isNaN(right)) {
+          return 0;
+        }
+        if (Number.isNaN(left)) {
+          return 1;
+        }
+        if (Number.isNaN(right)) {
+          return -1;
+        }
+        return left - right;
+      },
+      amount(a, b) {
+        return (a.amount || 0) - (b.amount || 0);
+      },
+    };
+
+    const updateSortIndicators = () => {
+      headerButtons.forEach((button) => {
+        const key = button.dataset.sortKey;
+        const th = button.closest('th');
+        if (!key || !th) {
+          return;
+        }
+
+        const isActive = currentSort.key === key;
+        button.dataset.sortIndicator = isActive
+          ? currentSort.direction === 'asc'
+            ? '▲'
+            : '▼'
+          : '';
+        th.setAttribute(
+          'aria-sort',
+          isActive
+            ? currentSort.direction === 'asc'
+              ? 'ascending'
+              : 'descending'
+            : 'none'
+        );
+      });
+    };
+
+    const renderRows = () => {
+      if (!tbody) {
+        return;
+      }
+
+      tbody.innerHTML = '';
+      if (!currentTransactions.length) {
+        const emptyRow = document.createElement('tr');
+        const cell = document.createElement('td');
+        cell.colSpan = 3;
+        cell.textContent = 'No hay movimientos registrados para este criterio.';
+        emptyRow.appendChild(cell);
+        tbody.appendChild(emptyRow);
+        return;
+      }
+
+      const sorted = [...currentTransactions];
+      const comparator = sortComparators[currentSort.key] || (() => 0);
+      sorted.sort((a, b) => {
+        const result = comparator(a, b);
+        return currentSort.direction === 'asc' ? result : -result;
+      });
+
+      sorted.forEach((transaction) => {
+        const row = document.createElement('tr');
+
+        const nameCell = document.createElement('td');
+        nameCell.textContent = transaction.name || '';
+        row.appendChild(nameCell);
+
+        const dateCell = document.createElement('td');
+        dateCell.textContent = formatDate(transaction.date);
+        row.appendChild(dateCell);
+
+        const amountCell = document.createElement('td');
+        amountCell.classList.add('visualizer__details-amount');
+        amountCell.textContent = formatCurrency(transaction.amount);
+        row.appendChild(amountCell);
+
+        tbody.appendChild(row);
+      });
+    };
+
+    headerButtons.forEach((button) => {
+      button.dataset.sortIndicator = '';
+      button.addEventListener('click', () => {
+        const key = button.dataset.sortKey;
+        if (!key) {
+          return;
+        }
+
+        if (currentSort.key === key) {
+          currentSort.direction = currentSort.direction === 'asc' ? 'desc' : 'asc';
+        } else {
+          currentSort = {
+            key,
+            direction: key === 'name' ? 'asc' : 'desc',
+          };
+        }
+
+        updateSortIndicators();
+        renderRows();
+      });
+    });
+
+    const showDetails = (entry) => {
+      if (!entry) {
+        section.hidden = true;
+        section.setAttribute('aria-hidden', 'true');
+        return;
+      }
+
+      currentTransactions = Array.isArray(entry.transactions)
+        ? entry.transactions.slice()
+        : [];
+      currentSort = { key: 'date', direction: 'desc' };
+      if (titleTarget) {
+        titleTarget.textContent = entry.name || '';
+      }
+
+      section.hidden = false;
+      section.setAttribute('aria-hidden', 'false');
+      updateSortIndicators();
+      renderRows();
+    };
+
+    updateSortIndicators();
+    renderRows();
+
+    return showDetails;
   }
 
   document.addEventListener('DOMContentLoaded', () => {
     const container = document.querySelector('.chart-card__inner');
     const chartData = readChartData();
-    renderChart(container, chartData);
+    const showDetails = initDetailsSection();
+    renderChart(container, chartData, showDetails);
 
     const form = document.querySelector('.controls');
     if (!form) {

--- a/invoice_classifier/static/invoice_classifier/visualizer.js
+++ b/invoice_classifier/static/invoice_classifier/visualizer.js
@@ -56,6 +56,23 @@
     });
   }
 
+  function hexToRgba(hex, alpha = 1) {
+    if (!/^#([0-9a-f]{3}){1,2}$/i.test(hex)) {
+      return hex;
+    }
+
+    const normalized = hex.replace('#', '');
+    const step = normalized.length === 3 ? 1 : 2;
+    const expand = (value) =>
+      step === 1 ? parseInt(value.repeat(2), 16) : parseInt(value, 16);
+
+    const r = expand(normalized.substring(0, step));
+    const g = expand(normalized.substring(step, step * 2));
+    const b = expand(normalized.substring(step * 2, step * 3));
+
+    return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+  }
+
   function renderChart(container, parsed, onBarClick) {
     if (!container || !Array.isArray(parsed) || parsed.length === 0) {
       return;
@@ -74,6 +91,9 @@
       return;
     }
 
+    const baseBackground = colors.map((color) => hexToRgba(color, 0.55));
+    let selectedIndex = null;
+
     const chart = new window.Chart(ctx, {
       type: 'bar',
       data: {
@@ -82,7 +102,8 @@
           {
             label: 'Gasto',
             data,
-            backgroundColor: colors,
+            backgroundColor: baseBackground,
+            hoverBackgroundColor: colors,
             borderRadius: 8,
           },
         ],
@@ -128,31 +149,40 @@
             },
           },
         },
-      },
-      onHover(event, elements) {
-        const canvas = event && event.chart ? event.chart.canvas : null;
-        if (!canvas) {
-          return;
-        }
+        onHover(event, elements) {
+          const canvas = event && event.chart ? event.chart.canvas : null;
+          if (!canvas) {
+            return;
+          }
 
-        canvas.style.cursor = elements.length ? 'pointer' : 'default';
-      },
-      onClick(_event, elements) {
-        if (!elements || elements.length === 0 || typeof onBarClick !== 'function') {
-          return;
-        }
+          canvas.style.cursor = elements.length ? 'pointer' : 'default';
+        },
+        onClick(_event, elements) {
+          if (!elements || elements.length === 0 || typeof onBarClick !== 'function') {
+            return;
+          }
 
-        const index = elements[0].index;
-        if (typeof index !== 'number') {
-          return;
-        }
+          const index = elements[0].index;
+          if (typeof index !== 'number') {
+            return;
+          }
 
-        const entry = parsed[index];
-        if (!entry) {
-          return;
-        }
+          const entry = parsed[index];
+          if (!entry) {
+            return;
+          }
 
-        onBarClick(entry, index);
+          selectedIndex = index;
+          const dataset = chart.data.datasets[0];
+          if (dataset) {
+            dataset.backgroundColor = colors.map((color, idx) =>
+              idx === selectedIndex ? color : hexToRgba(color, 0.35)
+            );
+            chart.update();
+          }
+
+          onBarClick(entry, index);
+        },
       },
     });
 

--- a/invoice_classifier/static/invoice_classifier/visualizer.js
+++ b/invoice_classifier/static/invoice_classifier/visualizer.js
@@ -91,7 +91,10 @@
       return;
     }
 
-    const baseBackground = colors.map((color) => hexToRgba(color, 0.55));
+    const defaultBackground = colors.slice();
+    const defaultHoverBackground = colors.map((color) =>
+      hexToRgba(color, 0.55)
+    );
     let selectedIndex = null;
 
     const chart = new window.Chart(ctx, {
@@ -102,8 +105,8 @@
           {
             label: 'Gasto',
             data,
-            backgroundColor: baseBackground,
-            hoverBackgroundColor: colors,
+            backgroundColor: defaultBackground,
+            hoverBackgroundColor: defaultHoverBackground,
             borderRadius: 8,
           },
         ],
@@ -177,6 +180,9 @@
           if (dataset) {
             dataset.backgroundColor = colors.map((color, idx) =>
               idx === selectedIndex ? color : hexToRgba(color, 0.35)
+            );
+            dataset.hoverBackgroundColor = colors.map((color, idx) =>
+              idx === selectedIndex ? hexToRgba(color, 0.55) : hexToRgba(color, 0.25)
             );
             chart.update();
           }

--- a/invoice_classifier/templates/invoice_classifier/visualizer.html
+++ b/invoice_classifier/templates/invoice_classifier/visualizer.html
@@ -89,6 +89,36 @@
           {% endif %}
         </section>
       </div>
+
+      <section class="visualizer__details" data-details hidden aria-hidden="true">
+        <h2 class="visualizer__details-title">
+          Movimientos de <span data-details-name></span>
+        </h2>
+        <div class="visualizer__details-table-wrapper">
+          <table class="visualizer__details-table">
+            <thead>
+              <tr>
+                <th scope="col" aria-sort="none">
+                  <button type="button" class="visualizer__sort-button" data-sort-key="name">
+                    Nombre
+                  </button>
+                </th>
+                <th scope="col" aria-sort="none">
+                  <button type="button" class="visualizer__sort-button" data-sort-key="date">
+                    Fecha
+                  </button>
+                </th>
+                <th scope="col" aria-sort="none" class="visualizer__details-amount">
+                  <button type="button" class="visualizer__sort-button" data-sort-key="amount">
+                    Importe
+                  </button>
+                </th>
+              </tr>
+            </thead>
+            <tbody data-details-body></tbody>
+          </table>
+        </div>
+      </section>
     </form>
   </section>
 {% endblock %}

--- a/invoice_classifier/views.py
+++ b/invoice_classifier/views.py
@@ -107,7 +107,7 @@ def index(request: HttpRequest) -> HttpResponse:
         transaction__amount__lt=0,
     )
 
-    aggregated_spending = (
+    aggregated_spending = list(
         classifications.values(
             "label__criterion__name", "label__criterion__slug", "label__criterion_id"
         )
@@ -115,16 +115,51 @@ def index(request: HttpRequest) -> HttpResponse:
         .order_by("label__criterion__name")
     )
 
-    chart_entries: list[dict[str, object]] = []
+    chart_entries_map: dict[str, dict[str, object]] = {}
     for entry in aggregated_spending:
         total_spent = entry.get("total_spent") or Decimal("0")
-        chart_entries.append(
+        slug = entry["label__criterion__slug"]
+        chart_entries_map[slug] = {
+            "slug": slug,
+            "name": entry["label__criterion__name"],
+            "total": float(-total_spent),
+            "transactions": [],
+        }
+
+    classified_transactions = classifications.select_related(
+        "transaction", "label__criterion"
+    ).order_by("transaction__booking_date", "transaction__id")
+
+    for classification in classified_transactions:
+        label = classification.label
+        if label is None:
+            continue
+
+        criterion = label.criterion
+        if criterion is None:
+            continue
+
+        entry = chart_entries_map.get(criterion.slug)
+        if entry is None:
+            continue
+
+        transaction = classification.transaction
+        if transaction is None:
+            continue
+
+        amount_value = transaction.amount if transaction.amount is not None else Decimal("0")
+
+        entry["transactions"].append(
             {
-                "slug": entry["label__criterion__slug"],
-                "name": entry["label__criterion__name"],
-                "total": float(-total_spent),
+                "name": transaction.concept,
+                "date": transaction.booking_date.isoformat()
+                if transaction.booking_date
+                else "",
+                "amount": float(-amount_value),
             }
         )
+
+    chart_entries = list(chart_entries_map.values())
 
     available_years_qs = BankTransaction.objects.filter(booking_date__isnull=False).dates(
         "booking_date", "year", order="ASC"


### PR DESCRIPTION
## Summary
- include the transactions behind each spending bar in the visualizer payload
- render an on-demand details section with a sortable table of the selected bar's movements
- style the details table and wire the chart so bars are clickable to show their movements

## Testing
- python manage.py check *(fails: Django not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d83052858c832fa49ff0c82888500b