### PR TITLE
Add single-criterion tab to visualizer

### DIFF
--- a/invoice_classifier/static/invoice_classifier/visualizer.css
+++ b/invoice_classifier/static/invoice_classifier/visualizer.css
@@ -29,6 +29,39 @@
   color: #1d4ed8;
 }
 
+.visualizer__tabs {
+  display: inline-flex;
+  gap: 0.5rem;
+  background: #e2e8f0;
+  padding: 0.35rem;
+  border-radius: 999px;
+  align-self: flex-start;
+}
+
+.visualizer__tab {
+  padding: 0.5rem 1.25rem;
+  border-radius: 999px;
+  font-weight: 600;
+  color: #475569;
+  text-decoration: none;
+  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.visualizer__tab:hover {
+  color: #0f172a;
+}
+
+.visualizer__tab--active {
+  background: white;
+  color: #1d4ed8;
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.12);
+}
+
+.visualizer__tab:focus-visible {
+  outline: 2px solid #2563eb;
+  outline-offset: 2px;
+}
+
 .controls {
   background: white;
   border-radius: 16px;
@@ -140,6 +173,10 @@
 .criteria-list__item input {
   width: 1.05rem;
   height: 1.05rem;
+}
+
+.criteria-list__item--radio input {
+  border-radius: 999px;
 }
 
 .controls__submit {

--- a/invoice_classifier/static/invoice_classifier/visualizer.js
+++ b/invoice_classifier/static/invoice_classifier/visualizer.js
@@ -363,10 +363,11 @@
       return;
     }
 
-    const monthSelect = form.querySelector('#month-select');
+    const monthSelect = form.querySelector('[data-month-select]');
     const modeInputs = form.querySelectorAll('input[name="mode"]');
     const criteriaInputs = form.querySelectorAll('input[name="criteria"]');
-    const yearSelect = form.querySelector('#year-select');
+    const singleCriterionInputs = form.querySelectorAll('input[name="criterion"]');
+    const yearSelect = form.querySelector('[data-year-select]');
 
     const submitForm = () => {
       if (typeof form.requestSubmit === 'function') {
@@ -376,13 +377,11 @@
       }
     };
 
-    const updateMonthAvailability = () => {
+    const updatePeriodControls = () => {
       const selectedMode = form.querySelector('input[name="mode"]:checked');
-      if (!monthSelect || !selectedMode) {
-        return;
+      if (monthSelect) {
+        monthSelect.disabled = !!selectedMode && selectedMode.value === 'yearly';
       }
-
-      monthSelect.disabled = selectedMode.value === 'yearly';
     };
 
     if (monthSelect) {
@@ -395,7 +394,7 @@
 
     modeInputs.forEach((input) => {
       input.addEventListener('change', () => {
-        updateMonthAvailability();
+        updatePeriodControls();
         submitForm();
       });
     });
@@ -404,6 +403,10 @@
       input.addEventListener('change', submitForm);
     });
 
-    updateMonthAvailability();
+    singleCriterionInputs.forEach((input) => {
+      input.addEventListener('change', submitForm);
+    });
+
+    updatePeriodControls();
   });
 })();

--- a/invoice_classifier/templates/invoice_classifier/visualizer.html
+++ b/invoice_classifier/templates/invoice_classifier/visualizer.html
@@ -23,103 +23,219 @@
       <p class="visualizer__period">Periodo seleccionado: <strong>{{ period_label }}</strong></p>
     </header>
 
-    <form class="controls" method="get">
-      <div class="controls__group controls__group--period">
-        <div class="field">
-          <label for="month-select">Mes</label>
-          <select id="month-select" name="month" {% if view_mode == 'yearly' %}disabled{% endif %}>
-            {% for value, label in month_choices %}
-              <option value="{{ value }}" {% if value == selected_month %}selected{% endif %}>
-                {{ label }}
-              </option>
-            {% endfor %}
-          </select>
-        </div>
-        <div class="field">
-          <label for="year-select">Año</label>
-          <select id="year-select" name="year">
-            {% for year in available_years %}
-              <option value="{{ year }}" {% if year == selected_year %}selected{% endif %}>{{ year }}</option>
-            {% endfor %}
-          </select>
-        </div>
-        <div class="field field--toggle">
-          <span>Modo</span>
-          <div class="toggle">
-            <label>
-              <input type="radio" name="mode" value="monthly" {% if view_mode == 'monthly' %}checked{% endif %} />
-              <span>Mensual</span>
-            </label>
-            <label>
-              <input type="radio" name="mode" value="yearly" {% if view_mode == 'yearly' %}checked{% endif %} />
-              <span>Anual</span>
-            </label>
-          </div>
-        </div>
-      </div>
+    <nav class="visualizer__tabs" role="tablist">
+      <a
+        class="visualizer__tab {% if active_tab == 'all' %}visualizer__tab--active{% endif %}"
+        href="{{ tab_links.all }}"
+        role="tab"
+        aria-selected="{% if active_tab == 'all' %}true{% else %}false{% endif %}"
+      >
+        All
+      </a>
+      <a
+        class="visualizer__tab {% if active_tab == 'single' %}visualizer__tab--active{% endif %}"
+        href="{{ tab_links.single }}"
+        role="tab"
+        aria-selected="{% if active_tab == 'single' %}true{% else %}false{% endif %}"
+      >
+        One by One
+      </a>
+    </nav>
 
-      <div class="visualizer__board">
-        <fieldset class="controls__group controls__group--criteria">
-          <legend>Selecciona criterios</legend>
-          <div class="criteria-list">
-            {% for criterion in criteria_list %}
-              <label class="criteria-list__item">
-                <input
-                  type="checkbox"
-                  name="criteria"
-                  value="{{ criterion.slug }}"
-                  {% if criterion.slug in selected_criteria_slugs %}checked{% endif %}
-                />
-                <span>{{ criterion.name }}</span>
+    {% if active_tab == 'all' %}
+      <form class="controls" method="get" data-tab="all">
+        <input type="hidden" name="tab" value="all" />
+        <div class="controls__group controls__group--period">
+          <div class="field">
+            <label for="month-select">Mes</label>
+            <select
+              id="month-select"
+              name="month"
+              data-month-select
+              {% if view_mode == 'yearly' %}disabled{% endif %}
+            >
+              {% for value, label in month_choices %}
+                <option value="{{ value }}" {% if value == selected_month %}selected{% endif %}>
+                  {{ label }}
+                </option>
+              {% endfor %}
+            </select>
+          </div>
+          <div class="field">
+            <label for="year-select">Año</label>
+            <select id="year-select" name="year" data-year-select>
+              {% for year in available_years %}
+                <option value="{{ year }}" {% if year == selected_year %}selected{% endif %}>{{ year }}</option>
+              {% endfor %}
+            </select>
+          </div>
+          <div class="field field--toggle">
+            <span>Modo</span>
+            <div class="toggle">
+              <label>
+                <input type="radio" name="mode" value="monthly" {% if view_mode == 'monthly' %}checked{% endif %} />
+                <span>Mensual</span>
               </label>
-            {% empty %}
-              <p>No hay criterios definidos todavía.</p>
-            {% endfor %}
-          </div>
-        </fieldset>
-
-        <section class="chart-card visualizer__chart">
-          {% if chart_entries %}
-            {{ chart_entries|json_script:"visualizer-chart-data" }}
-            <div class="chart-card__inner">
-              <canvas id="spending-chart" height="120"></canvas>
+              <label>
+                <input type="radio" name="mode" value="yearly" {% if view_mode == 'yearly' %}checked{% endif %} />
+                <span>Anual</span>
+              </label>
             </div>
-          {% else %}
-            <p class="chart-card__empty">No hay movimientos que coincidan con los filtros seleccionados.</p>
-          {% endif %}
-        </section>
-      </div>
-
-      <section class="visualizer__details" data-details hidden aria-hidden="true">
-        <h2 class="visualizer__details-title">
-          Movimientos de <span data-details-name></span>
-        </h2>
-        <div class="visualizer__details-table-wrapper">
-          <table class="visualizer__details-table">
-            <thead>
-              <tr>
-                <th scope="col" aria-sort="none">
-                  <button type="button" class="visualizer__sort-button" data-sort-key="name">
-                    Nombre
-                  </button>
-                </th>
-                <th scope="col" aria-sort="none">
-                  <button type="button" class="visualizer__sort-button" data-sort-key="date">
-                    Fecha
-                  </button>
-                </th>
-                <th scope="col" aria-sort="none" class="visualizer__details-amount">
-                  <button type="button" class="visualizer__sort-button" data-sort-key="amount">
-                    Importe
-                  </button>
-                </th>
-              </tr>
-            </thead>
-            <tbody data-details-body></tbody>
-          </table>
+          </div>
         </div>
-      </section>
-    </form>
+
+        <div class="visualizer__board">
+          <fieldset class="controls__group controls__group--criteria">
+            <legend>Selecciona criterios</legend>
+            <div class="criteria-list">
+              {% for criterion in criteria_list %}
+                <label class="criteria-list__item">
+                  <input
+                    type="checkbox"
+                    name="criteria"
+                    value="{{ criterion.slug }}"
+                    {% if criterion.slug in selected_criteria_slugs %}checked{% endif %}
+                  />
+                  <span>{{ criterion.name }}</span>
+                </label>
+              {% empty %}
+                <p>No hay criterios definidos todavía.</p>
+              {% endfor %}
+            </div>
+          </fieldset>
+
+          <section class="chart-card visualizer__chart">
+            {% if chart_entries %}
+              {{ chart_entries|json_script:"visualizer-chart-data" }}
+              <div class="chart-card__inner">
+                <canvas id="spending-chart" height="120"></canvas>
+              </div>
+            {% else %}
+              <p class="chart-card__empty">No hay movimientos que coincidan con los filtros seleccionados.</p>
+            {% endif %}
+          </section>
+        </div>
+
+        <section class="visualizer__details" data-details hidden aria-hidden="true">
+          <h2 class="visualizer__details-title">
+            Movimientos de <span data-details-name></span>
+          </h2>
+          <div class="visualizer__details-table-wrapper">
+            <table class="visualizer__details-table">
+              <thead>
+                <tr>
+                  <th scope="col" aria-sort="none">
+                    <button type="button" class="visualizer__sort-button" data-sort-key="name">
+                      Nombre
+                    </button>
+                  </th>
+                  <th scope="col" aria-sort="none">
+                    <button type="button" class="visualizer__sort-button" data-sort-key="date">
+                      Fecha
+                    </button>
+                  </th>
+                  <th scope="col" aria-sort="none" class="visualizer__details-amount">
+                    <button type="button" class="visualizer__sort-button" data-sort-key="amount">
+                      Importe
+                    </button>
+                  </th>
+                </tr>
+              </thead>
+              <tbody data-details-body></tbody>
+            </table>
+          </div>
+        </section>
+      </form>
+    {% else %}
+      <form class="controls" method="get" data-tab="single">
+        <input type="hidden" name="tab" value="single" />
+        <div class="controls__group controls__group--period">
+          <div class="field">
+            <label for="single-year-select">Año</label>
+            <select id="single-year-select" name="year" data-year-select>
+              {% for year in available_years %}
+                <option value="{{ year }}" {% if year == selected_year %}selected{% endif %}>{{ year }}</option>
+              {% endfor %}
+            </select>
+          </div>
+          <div class="field field--toggle">
+            <span>Modo</span>
+            <div class="toggle">
+              <label>
+                <input type="radio" name="mode" value="monthly" {% if view_mode == 'monthly' %}checked{% endif %} />
+                <span>Mensual</span>
+              </label>
+              <label>
+                <input type="radio" name="mode" value="yearly" {% if view_mode == 'yearly' %}checked{% endif %} />
+                <span>Anual</span>
+              </label>
+            </div>
+          </div>
+        </div>
+
+        <div class="visualizer__board">
+          <fieldset class="controls__group controls__group--criteria">
+            <legend>Selecciona un criterio</legend>
+            <div class="criteria-list">
+              {% for criterion in criteria_list %}
+                <label class="criteria-list__item criteria-list__item--radio">
+                  <input
+                    type="radio"
+                    name="criterion"
+                    value="{{ criterion.slug }}"
+                    {% if criterion.slug == selected_criterion_slug %}checked{% endif %}
+                  />
+                  <span>{{ criterion.name }}</span>
+                </label>
+              {% empty %}
+                <p>No hay criterios definidos todavía.</p>
+              {% endfor %}
+            </div>
+          </fieldset>
+
+          <section class="chart-card visualizer__chart">
+            {% if chart_entries %}
+              {{ chart_entries|json_script:"visualizer-chart-data" }}
+              <div class="chart-card__inner">
+                <canvas id="spending-chart" height="120"></canvas>
+              </div>
+            {% else %}
+              <p class="chart-card__empty">No hay movimientos que coincidan con los filtros seleccionados.</p>
+            {% endif %}
+          </section>
+        </div>
+
+        <section class="visualizer__details" data-details hidden aria-hidden="true">
+          <h2 class="visualizer__details-title">
+            Movimientos de <span data-details-name></span>
+          </h2>
+          <div class="visualizer__details-table-wrapper">
+            <table class="visualizer__details-table">
+              <thead>
+                <tr>
+                  <th scope="col" aria-sort="none">
+                    <button type="button" class="visualizer__sort-button" data-sort-key="name">
+                      Nombre
+                    </button>
+                  </th>
+                  <th scope="col" aria-sort="none">
+                    <button type="button" class="visualizer__sort-button" data-sort-key="date">
+                      Fecha
+                    </button>
+                  </th>
+                  <th scope="col" aria-sort="none" class="visualizer__details-amount">
+                    <button type="button" class="visualizer__sort-button" data-sort-key="amount">
+                      Importe
+                    </button>
+                  </th>
+                </tr>
+              </thead>
+              <tbody data-details-body></tbody>
+            </table>
+          </div>
+        </section>
+      </form>
+    {% endif %}
   </section>
 {% endblock %}
 

--- a/invoice_classifier/views.py
+++ b/invoice_classifier/views.py
@@ -13,7 +13,7 @@ from django.core.files.base import ContentFile
 from django.db import connection, transaction
 from django.db.models import Sum
 from django.db.utils import DatabaseError
-from django.http import HttpRequest, HttpResponse, JsonResponse
+from django.http import HttpRequest, HttpResponse, JsonResponse, QueryDict
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from django.views.decorators.csrf import ensure_csrf_cookie
@@ -58,6 +58,21 @@ def index(request: HttpRequest) -> HttpResponse:
     """Display aggregated spending per criterion using interactive controls."""
 
     today = timezone.localdate()
+    criteria_qs = ClassificationCriterion.objects.all().order_by("name")
+    available_criteria_slugs = list(criteria_qs.values_list("slug", flat=True))
+    active_tab = request.GET.get("tab", "all")
+    if active_tab not in {"all", "single"}:
+        active_tab = "all"
+
+    available_years_qs = BankTransaction.objects.filter(
+        booking_date__isnull=False
+    ).dates("booking_date", "year", order="ASC")
+    available_years = [dt.year for dt in available_years_qs]
+    if not available_years:
+        available_years = [today.year]
+
+    month_choices = [(index, MONTH_NAMES_ES[index]) for index in range(1, 13)]
+
     view_mode = request.GET.get("mode", "monthly")
     if view_mode not in {"monthly", "yearly"}:
         view_mode = "monthly"
@@ -75,111 +90,266 @@ def index(request: HttpRequest) -> HttpResponse:
     if not 1 <= selected_month <= 12:
         selected_month = today.month
 
-    criteria_qs = ClassificationCriterion.objects.all().order_by("name")
-    available_criteria_slugs = list(criteria_qs.values_list("slug", flat=True))
+    chart_entries: list[dict[str, object]] = []
+    period_label = ""
 
-    requested_slugs = [slug for slug in request.GET.getlist("criteria") if slug]
-    if requested_slugs:
-        selected_criteria_slugs = [
-            slug for slug in requested_slugs if slug in available_criteria_slugs
-        ]
-    else:
-        selected_criteria_slugs = available_criteria_slugs.copy()
+    if active_tab == "all":
+        requested_slugs = [slug for slug in request.GET.getlist("criteria") if slug]
+        if requested_slugs:
+            selected_criteria_slugs = [
+                slug for slug in requested_slugs if slug in available_criteria_slugs
+            ]
+        else:
+            selected_criteria_slugs = available_criteria_slugs.copy()
 
-    selected_criteria = list(
-        criteria_qs.filter(slug__in=selected_criteria_slugs).order_by("name")
-    )
-
-    if view_mode == "monthly":
-        period_start = date(selected_year, selected_month, 1)
-        _, days_in_month = monthrange(selected_year, selected_month)
-        period_end = period_start + timedelta(days=days_in_month)
-        period_label = f"{MONTH_NAMES_ES[period_start.month]} {period_start.year}"
-    else:
-        period_start = date(selected_year, 1, 1)
-        period_end = date(selected_year + 1, 1, 1)
-        period_label = f"{selected_year}"
-
-    classifications = TransactionClassification.objects.filter(
-        label__criterion__in=selected_criteria,
-        transaction__booking_date__gte=period_start,
-        transaction__booking_date__lt=period_end,
-        transaction__amount__lt=0,
-    )
-
-    aggregated_spending = list(
-        classifications.values(
-            "label__criterion__name", "label__criterion__slug", "label__criterion_id"
+        selected_criteria = list(
+            criteria_qs.filter(slug__in=selected_criteria_slugs).order_by("name")
         )
-        .annotate(total_spent=Sum("transaction__amount"))
-        .order_by("label__criterion__name")
-    )
 
-    chart_entries_map: dict[str, dict[str, object]] = {}
-    for entry in aggregated_spending:
-        total_spent = entry.get("total_spent") or Decimal("0")
-        slug = entry["label__criterion__slug"]
-        chart_entries_map[slug] = {
-            "slug": slug,
-            "name": entry["label__criterion__name"],
-            "total": float(-total_spent),
-            "transactions": [],
-        }
+        if view_mode == "monthly":
+            period_start = date(selected_year, selected_month, 1)
+            _, days_in_month = monthrange(selected_year, selected_month)
+            period_end = period_start + timedelta(days=days_in_month)
+            period_label = f"{MONTH_NAMES_ES[period_start.month]} {period_start.year}"
+        else:
+            period_start = date(selected_year, 1, 1)
+            period_end = date(selected_year + 1, 1, 1)
+            period_label = f"{selected_year}"
 
-    classified_transactions = classifications.select_related(
-        "transaction", "label__criterion"
-    ).order_by("transaction__booking_date", "transaction__id")
+        classifications = TransactionClassification.objects.filter(
+            label__criterion__in=selected_criteria,
+            transaction__booking_date__gte=period_start,
+            transaction__booking_date__lt=period_end,
+            transaction__amount__lt=0,
+        )
 
-    for classification in classified_transactions:
-        label = classification.label
-        if label is None:
-            continue
+        aggregated_spending = list(
+            classifications.values(
+                "label__criterion__name",
+                "label__criterion__slug",
+                "label__criterion_id",
+            )
+            .annotate(total_spent=Sum("transaction__amount"))
+            .order_by("label__criterion__name")
+        )
 
-        criterion = label.criterion
-        if criterion is None:
-            continue
-
-        entry = chart_entries_map.get(criterion.slug)
-        if entry is None:
-            continue
-
-        transaction = classification.transaction
-        if transaction is None:
-            continue
-
-        amount_value = transaction.amount if transaction.amount is not None else Decimal("0")
-
-        entry["transactions"].append(
-            {
-                "name": transaction.concept,
-                "date": transaction.booking_date.isoformat()
-                if transaction.booking_date
-                else "",
-                "amount": float(-amount_value),
+        chart_entries_map: dict[str, dict[str, object]] = {}
+        for entry in aggregated_spending:
+            total_spent = entry.get("total_spent") or Decimal("0")
+            slug = entry["label__criterion__slug"]
+            chart_entries_map[slug] = {
+                "slug": slug,
+                "name": entry["label__criterion__name"],
+                "total": float(-total_spent),
+                "transactions": [],
             }
-        )
 
-    chart_entries = list(chart_entries_map.values())
+        classified_transactions = classifications.select_related(
+            "transaction", "label__criterion"
+        ).order_by("transaction__booking_date", "transaction__id")
 
-    available_years_qs = BankTransaction.objects.filter(booking_date__isnull=False).dates(
-        "booking_date", "year", order="ASC"
-    )
-    available_years = [dt.year for dt in available_years_qs]
-    if not available_years:
-        available_years = [today.year]
+        for classification in classified_transactions:
+            label = classification.label
+            if label is None:
+                continue
 
-    month_choices = [(index, MONTH_NAMES_ES[index]) for index in range(1, 13)]
+            criterion = label.criterion
+            if criterion is None:
+                continue
 
-    context = {
-        "criteria_list": criteria_qs,
-        "selected_criteria_slugs": selected_criteria_slugs,
-        "view_mode": view_mode,
-        "selected_year": selected_year,
-        "selected_month": selected_month,
-        "period_label": period_label,
-        "chart_entries": chart_entries,
-        "available_years": available_years,
-        "month_choices": month_choices,
+            entry = chart_entries_map.get(criterion.slug)
+            if entry is None:
+                continue
+
+            transaction = classification.transaction
+            if transaction is None:
+                continue
+
+            amount_value = (
+                transaction.amount if transaction.amount is not None else Decimal("0")
+            )
+
+            entry["transactions"].append(
+                {
+                    "name": transaction.concept,
+                    "date": transaction.booking_date.isoformat()
+                    if transaction.booking_date
+                    else "",
+                    "amount": float(-amount_value),
+                }
+            )
+
+        chart_entries = list(chart_entries_map.values())
+
+        context = {
+            "criteria_list": criteria_qs,
+            "selected_criteria_slugs": selected_criteria_slugs,
+            "view_mode": view_mode,
+            "selected_year": selected_year,
+            "selected_month": selected_month,
+            "period_label": period_label,
+            "chart_entries": chart_entries,
+            "available_years": available_years,
+            "month_choices": month_choices,
+            "active_tab": active_tab,
+        }
+    else:
+        selected_criteria_slugs: list[str] = []
+        selected_criterion_slug = request.GET.get("criterion", "")
+        if selected_criterion_slug not in available_criteria_slugs:
+            selected_criterion_slug = available_criteria_slugs[0] if available_criteria_slugs else ""
+
+        selected_criterion = None
+        if selected_criterion_slug:
+            try:
+                selected_criterion = criteria_qs.get(slug=selected_criterion_slug)
+            except ClassificationCriterion.DoesNotExist:
+                selected_criterion = None
+
+        base_classifications = TransactionClassification.objects.none()
+        if selected_criterion is not None:
+            base_classifications = TransactionClassification.objects.filter(
+                label__criterion=selected_criterion,
+                transaction__amount__lt=0,
+                transaction__booking_date__isnull=False,
+            )
+
+        if selected_criterion is None:
+            period_label = ""
+            chart_entries = []
+        elif view_mode == "monthly":
+            year_start = date(selected_year, 1, 1)
+            year_end = date(selected_year + 1, 1, 1)
+            period_label = f"{selected_criterion.name} — {selected_year}"
+
+            entries_map: dict[int, dict[str, object]] = {
+                month: {
+                    "name": f"{MONTH_NAMES_ES[month]} {selected_year}",
+                    "total": Decimal("0"),
+                    "transactions": [],
+                }
+                for month in range(1, 13)
+            }
+
+            yearly_classifications = base_classifications.filter(
+                transaction__booking_date__gte=year_start,
+                transaction__booking_date__lt=year_end,
+            ).select_related("transaction")
+
+            for classification in yearly_classifications:
+                transaction = classification.transaction
+                if transaction is None or transaction.booking_date is None:
+                    continue
+
+                month = transaction.booking_date.month
+                entry = entries_map.get(month)
+                if entry is None:
+                    continue
+
+                amount_value = (
+                    transaction.amount if transaction.amount is not None else Decimal("0")
+                )
+
+                entry["total"] += -amount_value
+                entry["transactions"].append(
+                    {
+                        "name": transaction.concept,
+                        "date": transaction.booking_date.isoformat(),
+                        "amount": float(-(amount_value or Decimal("0"))),
+                    }
+                )
+
+            chart_entries = [
+                {
+                    "name": entries_map[month]["name"],
+                    "total": float(entries_map[month]["total"]),
+                    "transactions": entries_map[month]["transactions"],
+                }
+                for month in range(1, 13)
+            ]
+        else:
+            period_label = f"{selected_criterion.name} — Todos los años"
+
+            entries_map: dict[int, dict[str, object]] = {
+                year: {
+                    "name": str(year),
+                    "total": Decimal("0"),
+                    "transactions": [],
+                }
+                for year in available_years
+            }
+
+            yearly_classifications = base_classifications.select_related("transaction")
+
+            for classification in yearly_classifications:
+                transaction = classification.transaction
+                if transaction is None or transaction.booking_date is None:
+                    continue
+
+                year = transaction.booking_date.year
+                entry = entries_map.setdefault(
+                    year,
+                    {
+                        "name": str(year),
+                        "total": Decimal("0"),
+                        "transactions": [],
+                    },
+                )
+
+                amount_value = (
+                    transaction.amount if transaction.amount is not None else Decimal("0")
+                )
+
+                entry["total"] += -amount_value
+                entry["transactions"].append(
+                    {
+                        "name": transaction.concept,
+                        "date": transaction.booking_date.isoformat(),
+                        "amount": float(-(amount_value or Decimal("0"))),
+                    }
+                )
+
+            chart_entries = [
+                {
+                    "name": entries_map[year]["name"],
+                    "total": float(entries_map[year]["total"]),
+                    "transactions": entries_map[year]["transactions"],
+                }
+                for year in sorted(entries_map)
+            ]
+
+        context = {
+            "criteria_list": criteria_qs,
+            "selected_criteria_slugs": selected_criteria_slugs,
+            "view_mode": view_mode,
+            "selected_year": selected_year,
+            "period_label": period_label,
+            "chart_entries": chart_entries,
+            "available_years": available_years,
+            "active_tab": active_tab,
+            "selected_criterion_slug": selected_criterion_slug,
+        }
+        if view_mode == "monthly":
+            context["selected_month"] = None
+
+    context["month_choices"] = month_choices
+
+    base_query = request.GET.copy()
+    base_query.pop("tab", None)
+
+    all_query = base_query.copy()
+    all_query["tab"] = "all"
+
+    single_query = base_query.copy()
+    single_query["tab"] = "single"
+
+    def build_url(params: QueryDict) -> str:
+        query_string = params.urlencode()
+        return f"{request.path}?{query_string}" if query_string else request.path
+
+    context["tab_links"] = {
+        "all": build_url(all_query),
+        "single": build_url(single_query),
     }
 
     return render(


### PR DESCRIPTION
## Summary
- add tabbed navigation to the visualizer so users can switch between the existing "All" view and a new "One by One" mode
- compute per-criterion monthly and yearly data for the one-by-one tab while keeping the existing aggregated behaviour for the all tab
- refresh the template, styles, and JavaScript so the new controls submit automatically and remain interactive across both tabs

## Testing
- python manage.py test *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68d83c3f13a4832fa48a21e4aae4aa2f