### PR TITLE
Add light and dark theme toggle

### DIFF
--- a/invoice_classifier/static/invoice_classifier/index.css
+++ b/invoice_classifier/static/invoice_classifier/index.css
@@ -1,12 +1,7 @@
-:root {
-  color-scheme: light dark;
-  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-}
-
 body.index-body {
   margin: 0;
-  background: #0f172a;
-  color: #f8fafc;
+  background: var(--color-background);
+  color: var(--color-on-background);
 }
 
 .content--index {
@@ -24,9 +19,9 @@ body.index-body {
 }
 
 .card {
-  background: rgba(15, 23, 42, 0.9);
+  background: var(--color-surface-elevated);
   border-radius: 18px;
-  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.45);
+  box-shadow: 0 20px 45px var(--shadow-strong);
   width: min(640px, 100%);
   padding: 2.5rem;
 }
@@ -49,17 +44,17 @@ input[type="file"] {
   font: inherit;
   padding: 0.65rem 0.75rem;
   border-radius: 10px;
-  border: 1px solid rgba(148, 163, 184, 0.4);
-  background: rgba(15, 23, 42, 0.75);
-  color: inherit;
+  border: 1px solid var(--color-input-border);
+  background: var(--color-input-bg);
+  color: var(--color-on-surface);
   transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
 input[type="text"]:focus,
 input[type="file"]:focus {
   outline: none;
-  border-color: #38bdf8;
-  box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.25);
+  border-color: var(--color-input-border-strong);
+  box-shadow: 0 0 0 3px var(--color-accent-soft);
 }
 
 button {
@@ -70,7 +65,7 @@ button {
   background: linear-gradient(135deg, #38bdf8, #6366f1);
   border: none;
   border-radius: 999px;
-  color: #0f172a;
+  color: var(--color-accent-contrast);
   cursor: pointer;
   font-weight: 700;
   font-size: 1rem;
@@ -101,23 +96,23 @@ button[disabled] {
 }
 
 .message.success {
-  background: rgba(34, 197, 94, 0.2);
-  border: 1px solid rgba(34, 197, 94, 0.4);
-  color: #bbf7d0;
+  background: var(--color-success-bg);
+  border: 1px solid var(--color-success-border);
+  color: var(--color-success-text);
 }
 
 .message.error {
-  background: rgba(239, 68, 68, 0.2);
-  border: 1px solid rgba(239, 68, 68, 0.4);
-  color: #fecaca;
+  background: var(--color-error-bg);
+  border: 1px solid var(--color-error-border);
+  color: var(--color-error-text);
 }
 
 .result {
   margin-top: 1.25rem;
   padding: 1rem 1.25rem;
   border-radius: 12px;
-  background: rgba(148, 163, 184, 0.12);
-  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: var(--color-surface-subtle);
+  border: 1px solid var(--color-border);
 }
 
 .result dt {

--- a/invoice_classifier/static/invoice_classifier/visualizer.css
+++ b/invoice_classifier/static/invoice_classifier/visualizer.css
@@ -19,20 +19,20 @@
 
 .visualizer__subtitle {
   margin: 0.35rem 0 0;
-  color: #475569;
+  color: var(--color-muted);
   max-width: 60ch;
 }
 
 .visualizer__period {
   margin: 0;
   font-weight: 500;
-  color: #1d4ed8;
+  color: var(--color-accent);
 }
 
 .visualizer__tabs {
   display: inline-flex;
   gap: 0.5rem;
-  background: #e2e8f0;
+  background: var(--color-chart-tab-bg);
   padding: 0.35rem;
   border-radius: 999px;
   align-self: flex-start;
@@ -42,31 +42,31 @@
   padding: 0.5rem 1.25rem;
   border-radius: 999px;
   font-weight: 600;
-  color: #475569;
+  color: var(--color-muted);
   text-decoration: none;
   transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
 }
 
 .visualizer__tab:hover {
-  color: #0f172a;
+  color: var(--color-chart-tab-hover-text);
 }
 
 .visualizer__tab--active {
-  background: white;
-  color: #1d4ed8;
-  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.12);
+  background: var(--color-chart-tab-active-bg);
+  color: var(--color-chart-tab-active-text);
+  box-shadow: 0 10px 30px var(--shadow-soft);
 }
 
 .visualizer__tab:focus-visible {
-  outline: 2px solid #2563eb;
+  outline: 2px solid var(--color-accent);
   outline-offset: 2px;
 }
 
 .controls {
-  background: white;
+  background: var(--color-surface);
   border-radius: 16px;
   padding: 1.5rem;
-  box-shadow: 0 12px 40px rgba(15, 23, 42, 0.08);
+  box-shadow: 0 12px 40px var(--shadow-soft);
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
@@ -92,15 +92,16 @@
 .field label,
 .field span {
   font-weight: 600;
-  color: #0f172a;
+  color: var(--color-on-surface);
 }
 
 .field select {
   padding: 0.55rem 0.75rem;
   border-radius: 8px;
-  border: 1px solid #cbd5f5;
-  background: #f8fafc;
+  border: 1px solid var(--color-input-border);
+  background: var(--color-input-bg);
   font: inherit;
+  color: var(--color-on-surface);
 }
 
 .field--toggle {
@@ -111,7 +112,7 @@
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;
-  background: #e2e8f0;
+  background: var(--color-chart-tab-bg);
   border-radius: 999px;
   padding: 0.25rem;
 }
@@ -124,7 +125,7 @@
   border-radius: 999px;
   cursor: pointer;
   font-weight: 600;
-  color: #475569;
+  color: var(--color-muted);
 }
 
 .toggle input {
@@ -132,8 +133,8 @@
 }
 
 .toggle input:checked + span {
-  background: #1d4ed8;
-  color: white;
+  background: var(--color-accent);
+  color: var(--color-accent-contrast);
   padding: 0.25rem 0.65rem;
   border-radius: 999px;
 }
@@ -149,7 +150,7 @@
 
 .controls__group--criteria legend {
   font-weight: 600;
-  color: #0f172a;
+  color: var(--color-on-surface);
 }
 
 .criteria-list {
@@ -164,10 +165,11 @@
   gap: 0.65rem;
   padding: 0.5rem 0.75rem;
   border-radius: 10px;
-  border: 1px solid #cbd5f5;
-  background: #f8fafc;
+  border: 1px solid var(--color-input-border);
+  background: var(--color-surface-subtle);
   font-weight: 500;
   cursor: pointer;
+  color: var(--color-on-surface);
 }
 
 .criteria-list__item input {
@@ -184,22 +186,22 @@
   padding: 0.75rem 1.5rem;
   border-radius: 999px;
   border: none;
-  background: #2563eb;
-  color: white;
+  background: var(--color-accent);
+  color: var(--color-accent-contrast);
   font-weight: 600;
   cursor: pointer;
-  box-shadow: 0 10px 24px rgba(37, 99, 235, 0.25);
+  box-shadow: 0 10px 24px var(--shadow-soft);
 }
 
 .controls__submit:hover {
-  background: #1d4ed8;
+  background: var(--color-accent-strong);
 }
 
 .chart-card {
-  background: white;
+  background: var(--color-surface);
   border-radius: 18px;
   padding: 1.5rem;
-  box-shadow: 0 18px 50px rgba(15, 23, 42, 0.1);
+  box-shadow: 0 18px 50px var(--shadow-soft);
 }
 
 .visualizer__board {
@@ -226,14 +228,14 @@
 .chart-card__empty {
   margin: 0;
   text-align: center;
-  color: #475569;
+  color: var(--color-muted);
 }
 
 .visualizer__details {
-  background: white;
+  background: var(--color-surface);
   border-radius: 18px;
   padding: 1.5rem;
-  box-shadow: 0 18px 50px rgba(15, 23, 42, 0.1);
+  box-shadow: 0 18px 50px var(--shadow-soft);
   display: flex;
   flex-direction: column;
   gap: 1rem;
@@ -246,11 +248,11 @@
 .visualizer__details-title {
   margin: 0;
   font-size: 1.25rem;
-  color: #0f172a;
+  color: var(--color-on-surface);
 }
 
 .visualizer__details-title span {
-  color: #1d4ed8;
+  color: var(--color-accent);
 }
 
 .visualizer__details-table-wrapper {
@@ -267,12 +269,12 @@
 .visualizer__details-table td {
   padding: 0.75rem 1rem;
   text-align: left;
-  border-bottom: 1px solid #e2e8f0;
-  color: #0f172a;
+  border-bottom: 1px solid var(--color-table-border);
+  color: var(--color-on-surface);
 }
 
 .visualizer__details-table tbody tr:hover {
-  background: #f8fafc;
+  background: var(--color-table-hover);
 }
 
 .visualizer__details-amount {
@@ -285,7 +287,7 @@
   background: transparent;
   font: inherit;
   font-weight: 600;
-  color: #0f172a;
+  color: var(--color-on-surface);
   display: inline-flex;
   align-items: center;
   gap: 0.35rem;
@@ -296,11 +298,11 @@
 .visualizer__sort-button::after {
   content: attr(data-sort-indicator);
   font-size: 0.75em;
-  color: #64748b;
+  color: var(--color-muted);
 }
 
 .visualizer__sort-button:focus-visible {
-  outline: 2px solid #2563eb;
+  outline: 2px solid var(--color-accent);
   outline-offset: 2px;
 }
 

--- a/invoice_classifier/templates/invoice_classifier/base.html
+++ b/invoice_classifier/templates/invoice_classifier/base.html
@@ -1,24 +1,115 @@
 {% load static %}
 <!DOCTYPE html>
-<html lang="es">
+<html lang="es" data-theme="light">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>{% block title %}Bank Informer{% endblock %}</title>
+    <script>
+      (function () {
+        try {
+          var storageKey = "bank-informer-theme";
+          var storedTheme = localStorage.getItem(storageKey);
+          var prefersDark = window.matchMedia("(prefers-color-scheme: dark)");
+          var theme = storedTheme || (prefersDark.matches ? "dark" : "light");
+          var docEl = document.documentElement;
+          docEl.setAttribute("data-theme", theme);
+          docEl.style.colorScheme = theme === "dark" ? "dark" : "light";
+        } catch (error) {
+          document.documentElement.setAttribute("data-theme", "light");
+          document.documentElement.style.colorScheme = "light";
+        }
+      })();
+    </script>
     <style>
       :root {
         color-scheme: light;
         font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont,
           "Segoe UI", sans-serif;
         line-height: 1.5;
-        background-color: #f4f4f5;
+        --color-background: #f4f4f5;
+        --color-on-background: #0f172a;
+        --color-surface: #ffffff;
+        --color-on-surface: #0f172a;
+        --color-surface-elevated: #ffffff;
+        --color-surface-subtle: #f8fafc;
+        --color-muted: #475569;
+        --color-accent: #2563eb;
+        --color-accent-strong: #1d4ed8;
+        --color-accent-soft: rgba(37, 99, 235, 0.15);
+        --color-accent-contrast: #ffffff;
+        --color-border: #e2e8f0;
+        --color-input-bg: #ffffff;
+        --color-input-border: #cbd5f5;
+        --color-input-border-strong: #94a3b8;
+        --color-success-bg: rgba(34, 197, 94, 0.12);
+        --color-success-border: rgba(34, 197, 94, 0.35);
+        --color-success-text: #166534;
+        --color-error-bg: rgba(239, 68, 68, 0.12);
+        --color-error-border: rgba(239, 68, 68, 0.35);
+        --color-error-text: #b91c1c;
+        --color-table-border: #e2e8f0;
+        --color-table-hover: #f8fafc;
+        --color-chart-tab-bg: #e2e8f0;
+        --color-chart-tab-hover-text: #0f172a;
+        --color-chart-tab-active-bg: #ffffff;
+        --color-chart-tab-active-text: #1d4ed8;
+        --shadow-soft: rgba(15, 23, 42, 0.08);
+        --shadow-strong: rgba(15, 23, 42, 0.16);
+        --nav-bg: #1f2937;
+        --nav-text: #f8fafc;
+        --nav-hover-bg: rgba(148, 163, 184, 0.2);
+        --nav-active-bg: #3b82f6;
+        --toggle-border: rgba(148, 163, 184, 0.4);
+        --toggle-hover-border: rgba(148, 163, 184, 0.55);
+        --toggle-hover-bg: rgba(148, 163, 184, 0.15);
+      }
+
+      :root[data-theme="dark"] {
+        color-scheme: dark;
+        --color-background: #0f172a;
+        --color-on-background: #e2e8f0;
+        --color-surface: #111827;
+        --color-on-surface: #e2e8f0;
+        --color-surface-elevated: rgba(17, 24, 39, 0.95);
+        --color-surface-subtle: rgba(30, 41, 59, 0.65);
+        --color-muted: #94a3b8;
+        --color-accent: #60a5fa;
+        --color-accent-strong: #3b82f6;
+        --color-accent-soft: rgba(96, 165, 250, 0.25);
+        --color-accent-contrast: #0f172a;
+        --color-border: rgba(148, 163, 184, 0.2);
+        --color-input-bg: rgba(15, 23, 42, 0.75);
+        --color-input-border: rgba(148, 163, 184, 0.35);
+        --color-input-border-strong: rgba(148, 163, 184, 0.65);
+        --color-success-bg: rgba(34, 197, 94, 0.18);
+        --color-success-border: rgba(34, 197, 94, 0.35);
+        --color-success-text: #bbf7d0;
+        --color-error-bg: rgba(239, 68, 68, 0.2);
+        --color-error-border: rgba(239, 68, 68, 0.4);
+        --color-error-text: #fecaca;
+        --color-table-border: rgba(148, 163, 184, 0.18);
+        --color-table-hover: rgba(30, 41, 59, 0.65);
+        --color-chart-tab-bg: rgba(148, 163, 184, 0.18);
+        --color-chart-tab-hover-text: #f8fafc;
+        --color-chart-tab-active-bg: rgba(15, 23, 42, 0.45);
+        --color-chart-tab-active-text: #f8fafc;
+        --shadow-soft: rgba(2, 6, 23, 0.55);
+        --shadow-strong: rgba(2, 6, 23, 0.7);
+        --nav-bg: rgba(15, 23, 42, 0.85);
+        --nav-text: #e2e8f0;
+        --nav-hover-bg: rgba(148, 163, 184, 0.25);
+        --nav-active-bg: #2563eb;
+        --toggle-border: rgba(148, 163, 184, 0.35);
+        --toggle-hover-border: rgba(148, 163, 184, 0.6);
+        --toggle-hover-bg: rgba(148, 163, 184, 0.2);
       }
 
       body {
         margin: 0;
         min-height: 100vh;
-        background: #f4f4f5;
-        color: #0f172a;
+        background: var(--color-background);
+        color: var(--color-on-background);
       }
 
       a {
@@ -54,6 +145,85 @@
         {% block content %}{% endblock %}
       </main>
     </div>
+    <script>
+      (function () {
+        var storageKey = "bank-informer-theme";
+        var docEl = document.documentElement;
+        var prefersDark = window.matchMedia("(prefers-color-scheme: dark)");
+
+        function applyTheme(theme) {
+          docEl.setAttribute("data-theme", theme);
+          docEl.style.colorScheme = theme === "dark" ? "dark" : "light";
+        }
+
+        function persistTheme(theme) {
+          try {
+            localStorage.setItem(storageKey, theme);
+          } catch (error) {
+            /* localStorage might be unavailable */
+          }
+        }
+
+        function updateToggleButtons(theme) {
+          var isDark = theme === "dark";
+          var icon = isDark ? "☀️" : "🌙";
+          var text = isDark ? "Modo claro" : "Modo oscuro";
+
+          document.querySelectorAll(".js-theme-toggle").forEach(function (button) {
+            button.setAttribute("aria-pressed", isDark ? "true" : "false");
+
+            var iconEl = button.querySelector(".theme-toggle__icon");
+            if (iconEl) {
+              iconEl.textContent = icon;
+            }
+
+            var textEl = button.querySelector(".theme-toggle__text");
+            if (textEl) {
+              textEl.textContent = text;
+            }
+          });
+        }
+
+        function getStoredTheme() {
+          try {
+            return localStorage.getItem(storageKey);
+          } catch (error) {
+            return null;
+          }
+        }
+
+        document.addEventListener("DOMContentLoaded", function () {
+          updateToggleButtons(docEl.getAttribute("data-theme") || "light");
+
+          document
+            .querySelectorAll(".js-theme-toggle")
+            .forEach(function (button) {
+              button.addEventListener("click", function () {
+                var currentTheme = docEl.getAttribute("data-theme") === "dark" ? "dark" : "light";
+                var newTheme = currentTheme === "dark" ? "light" : "dark";
+
+                applyTheme(newTheme);
+                persistTheme(newTheme);
+                updateToggleButtons(newTheme);
+              });
+            });
+        });
+
+        function handlePreferenceChange(event) {
+          if (!getStoredTheme()) {
+            var theme = event.matches ? "dark" : "light";
+            applyTheme(theme);
+            updateToggleButtons(theme);
+          }
+        }
+
+        if (typeof prefersDark.addEventListener === "function") {
+          prefersDark.addEventListener("change", handlePreferenceChange);
+        } else if (typeof prefersDark.addListener === "function") {
+          prefersDark.addListener(handlePreferenceChange);
+        }
+      })();
+    </script>
     {% block extra_scripts %}{% endblock %}
   </body>
 </html>

--- a/invoice_classifier/templates/invoice_classifier/manage_criteria.html
+++ b/invoice_classifier/templates/invoice_classifier/manage_criteria.html
@@ -25,9 +25,9 @@
     }
 
     .criteria-page .messages li {
-      background: #ecfdf5;
-      border: 1px solid #34d399;
-      color: #065f46;
+      background: var(--color-success-bg);
+      border: 1px solid var(--color-success-border);
+      color: var(--color-success-text);
       padding: 0.75rem 1rem;
       border-radius: 0.75rem;
       margin-bottom: 0.5rem;
@@ -40,10 +40,10 @@
     }
 
     .criteria-page .panel {
-      background: #ffffff;
+      background: var(--color-surface-elevated);
       border-radius: 1rem;
       padding: 1.5rem;
-      box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+      box-shadow: 0 10px 30px var(--shadow-soft);
     }
 
     .criteria-page form {
@@ -63,7 +63,8 @@
       width: 100%;
       padding: 0.6rem 0.75rem;
       border-radius: 0.5rem;
-      border: 1px solid #d4d4d8;
+      border: 1px solid var(--color-input-border);
+      background: var(--color-input-bg);
       font-size: 0.95rem;
       box-sizing: border-box;
     }
@@ -74,20 +75,20 @@
 
     .criteria-page .helptext {
       font-size: 0.8rem;
-      color: #52525b;
+      color: var(--color-muted);
     }
 
     .criteria-page .errorlist {
       margin: 0.25rem 0 0;
       padding-left: 1.1rem;
-      color: #b91c1c;
+      color: var(--color-error-text);
       font-size: 0.85rem;
     }
 
     .criteria-page button {
       justify-self: start;
-      background: #2563eb;
-      color: #ffffff;
+      background: var(--color-accent);
+      color: var(--color-accent-contrast);
       border: none;
       border-radius: 0.5rem;
       padding: 0.6rem 1.25rem;
@@ -97,7 +98,7 @@
     }
 
     .criteria-page button:hover {
-      background: #1d4ed8;
+      background: var(--color-accent-strong);
     }
 
     .criteria-page .criteria-list {
@@ -113,10 +114,10 @@
     }
 
     .criteria-page .criteria-item {
-      border: 1px solid #e4e4e7;
+      border: 1px solid var(--color-border);
       border-radius: 0.75rem;
       padding: 0.75rem 1rem;
-      background: #fafafa;
+      background: var(--color-surface-subtle);
     }
 
     .criteria-page .criteria-item strong {
@@ -126,7 +127,7 @@
     }
 
     .criteria-page .criteria-item a {
-      color: #2563eb;
+      color: var(--color-accent);
       text-decoration: none;
       font-weight: 600;
     }
@@ -136,10 +137,10 @@
     }
 
     .criteria-page .transaction-list {
-      background: #ffffff;
+      background: var(--color-surface-elevated);
       border-radius: 1rem;
       padding: 1rem;
-      box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+      box-shadow: 0 10px 30px var(--shadow-soft);
       max-height: 420px;
       overflow-y: auto;
     }
@@ -153,14 +154,14 @@
     .criteria-page td {
       text-align: left;
       padding: 0.5rem 0.75rem;
-      border-bottom: 1px solid #e4e4e7;
+      border-bottom: 1px solid var(--color-table-border);
       font-size: 0.9rem;
     }
 
     .criteria-page th {
       position: sticky;
       top: 0;
-      background: #ffffff;
+      background: var(--color-surface-elevated);
       z-index: 1;
     }
 

--- a/invoice_classifier/templates/invoice_classifier/partials/navbar.html
+++ b/invoice_classifier/templates/invoice_classifier/partials/navbar.html
@@ -1,40 +1,51 @@
 <nav class="top-nav">
   <div class="top-nav__inner">
     <a class="top-nav__brand" href="{% url 'index' %}">Bank Informer</a>
-    <ul class="top-nav__links">
-      <li>
-        <a href="{% url 'index' %}" class="{% if active_page == 'index' %}is-active{% endif %}">
-          Visualizador
-        </a>
-      </li>
-      <li>
-        <a href="{% url 'manage_classification_criteria' %}" class="{% if active_page == 'criteria' %}is-active{% endif %}">
-          Criterios
-        </a>
-      </li>
-      <li>
-        <a href="{% url 'upload_csv' %}" class="{% if active_page == 'upload' %}is-active{% endif %}">
-          Upload CSV
-        </a>
-      </li>
-      <li>
-        <a href="{% url 'debug_sql_console' %}" class="{% if active_page == 'sql' %}is-active{% endif %}">
-          SQL
-        </a>
-      </li>
-      <li>
-        <a href="{% url 'admin:index' %}" class="{% if active_page == 'admin' %}is-active{% endif %}">
-          Admin
-        </a>
-      </li>
-    </ul>
+    <div class="top-nav__actions">
+      <ul class="top-nav__links">
+        <li>
+          <a href="{% url 'index' %}" class="{% if active_page == 'index' %}is-active{% endif %}">
+            Visualizador
+          </a>
+        </li>
+        <li>
+          <a href="{% url 'manage_classification_criteria' %}" class="{% if active_page == 'criteria' %}is-active{% endif %}">
+            Criterios
+          </a>
+        </li>
+        <li>
+          <a href="{% url 'upload_csv' %}" class="{% if active_page == 'upload' %}is-active{% endif %}">
+            Upload CSV
+          </a>
+        </li>
+        <li>
+          <a href="{% url 'debug_sql_console' %}" class="{% if active_page == 'sql' %}is-active{% endif %}">
+            SQL
+          </a>
+        </li>
+        <li>
+          <a href="{% url 'admin:index' %}" class="{% if active_page == 'admin' %}is-active{% endif %}">
+            Admin
+          </a>
+        </li>
+      </ul>
+      <button
+        type="button"
+        class="theme-toggle js-theme-toggle"
+        aria-pressed="false"
+        aria-label="Cambiar tema"
+      >
+        <span class="theme-toggle__icon" aria-hidden="true">🌙</span>
+        <span class="theme-toggle__text">Modo oscuro</span>
+      </button>
+    </div>
   </div>
 </nav>
 <style>
   .top-nav {
-    background: #1f2937;
-    color: #f8fafc;
-    box-shadow: 0 2px 12px rgba(15, 23, 42, 0.16);
+    background: var(--nav-bg);
+    color: var(--nav-text);
+    box-shadow: 0 2px 12px var(--shadow-soft);
   }
 
   .top-nav__inner {
@@ -52,6 +63,12 @@
     letter-spacing: -0.01em;
     text-decoration: none;
     color: inherit;
+  }
+
+  .top-nav__actions {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
   }
 
   .top-nav__links {
@@ -72,12 +89,47 @@
   }
 
   .top-nav__links a:hover {
-    background: rgba(148, 163, 184, 0.2);
+    background: var(--nav-hover-bg);
   }
 
   .top-nav__links a.is-active {
-    background: #3b82f6;
-    color: white;
+    background: var(--nav-active-bg);
+    color: var(--color-accent-contrast);
+  }
+
+  .theme-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.35rem 0.85rem;
+    border-radius: 999px;
+    background: transparent;
+    border: 1px solid var(--toggle-border);
+    color: inherit;
+    font: inherit;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.2s ease, border-color 0.2s ease;
+  }
+
+  .theme-toggle:hover,
+  .theme-toggle:focus-visible {
+    background: var(--toggle-hover-bg);
+    border-color: var(--toggle-hover-border);
+    outline: none;
+  }
+
+  .theme-toggle:focus-visible {
+    box-shadow: 0 0 0 2px var(--color-accent);
+  }
+
+  .theme-toggle__icon {
+    font-size: 1rem;
+    line-height: 1;
+  }
+
+  .theme-toggle__text {
+    font-size: 0.875rem;
   }
 
   @media (max-width: 640px) {
@@ -86,9 +138,20 @@
       align-items: flex-start;
     }
 
+    .top-nav__actions {
+      width: 100%;
+      flex-wrap: wrap;
+      justify-content: space-between;
+      gap: 0.75rem;
+    }
+
     .top-nav__links {
       flex-wrap: wrap;
       gap: 0.5rem;
+    }
+
+    .theme-toggle {
+      margin-left: auto;
     }
   }
 </style>


### PR DESCRIPTION
## Summary
- add theme-aware CSS variables and scripts to persist the selected light or dark mode
- expose a navbar toggle so users can switch themes from anywhere in the app
- update visualizer and index styles to consume the shared design tokens for both themes

## Testing
- `python manage.py test` *(fails: Django is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d8618a9550832fb2e28da628a70c90