### PR TITLE
Ensure statement upload success message renders text

### DIFF
--- a/invoice_classifier/static/invoice_classifier/statement_upload.js
+++ b/invoice_classifier/static/invoice_classifier/statement_upload.js
@@ -19,6 +19,27 @@ createApp({
       const match = document.cookie.match(/csrftoken=([^;]+)/);
       return match ? decodeURIComponent(match[1]) : "";
     },
+    statementSummary() {
+      if (!this.result) {
+        return "";
+      }
+
+      const statementId = this.result.statement_id;
+      const fileName = this.result.file_name || "";
+
+      const idText = statementId ? `#${statementId}` : "";
+      return [idText, fileName].filter(Boolean).join(" · ");
+    },
+    transactionsCreated() {
+      if (!this.result) {
+        return "";
+      }
+
+      const { transactions_created: transactionsCreated } = this.result;
+      return typeof transactionsCreated === "number"
+        ? transactionsCreated
+        : transactionsCreated || "";
+    },
   },
   methods: {
     onFileChange(event) {

--- a/invoice_classifier/templates/invoice_classifier/upload_csv.html
+++ b/invoice_classifier/templates/invoice_classifier/upload_csv.html
@@ -57,18 +57,21 @@
         </button>
       </form>
 
-      <div v-if="message" class="message" :class="messageType">
-        {{ message }}
-      </div>
+      <div
+        v-if="message"
+        class="message"
+        :class="messageType"
+        v-text="message"
+      ></div>
 
       <dl v-if="result" class="result">
         <div>
           <dt>Importación</dt>
-          <dd>#{{ result.statement_id }} · {{ result.file_name }}</dd>
+          <dd v-text="statementSummary"></dd>
         </div>
         <div>
           <dt>Movimientos creados</dt>
-          <dd>{{ result.transactions_created }}</dd>
+          <dd v-text="transactionsCreated"></dd>
         </div>
       </dl>
     </div>


### PR DESCRIPTION
## Summary
- replace template interpolations with `v-text` bindings so Vue can render upload feedback
- add computed helpers for the statement summary and transaction count displayed after an upload

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e9988680f0832f867dd9a399cf18c3