### PR TITLE
Prevent duplicate CSV rows during statement import

### DIFF
--- a/invoice_classifier/static/invoice_classifier/statement_upload.js
+++ b/invoice_classifier/static/invoice_classifier/statement_upload.js
@@ -78,9 +78,16 @@ createApp({
           throw new Error(payload.error || "No se ha podido completar la importación.");
         }
 
-        this.message = "Importación realizada correctamente.";
-        this.messageType = "success";
         this.result = payload;
+        const ignored = Number(payload.transactions_ignored || 0);
+        if (ignored > 0) {
+          const plural = ignored === 1 ? "entrada duplicada" : "entradas duplicadas";
+          const verb = ignored === 1 ? "ha" : "han";
+          this.message = `Importación realizada correctamente. Se ${verb} ignorado ${ignored} ${plural}.`;
+        } else {
+          this.message = "Importación realizada correctamente.";
+        }
+        this.messageType = "success";
         this.sourceName = "";
         this.file = null;
         this.$refs.fileInput.value = "";

--- a/invoice_classifier/tests.py
+++ b/invoice_classifier/tests.py
@@ -1,3 +1,127 @@
-from django.test import TestCase
+import io
+from datetime import date
 
-# Create your tests here.
+from django.contrib.auth import get_user_model
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import TestCase
+from django.urls import reverse
+
+from .models import BankTransaction, StatementImport
+
+
+class UploadStatementTests(TestCase):
+    def setUp(self) -> None:
+        self.user = get_user_model().objects.create_user(
+            username="user", email="user@example.com", password="secret"
+        )
+        self.client.force_login(self.user)
+        self.url = reverse("upload_statement")
+
+    def _build_csv(self, rows: list[list[str]]) -> SimpleUploadedFile:
+        content = io.StringIO()
+        content.write("Encabezado 1\n")
+        content.write("Encabezado 2\n")
+        content.write("Concepto;Fecha;Importe;Saldo disponible\n")
+        for row in rows:
+            content.write(";".join(row) + "\n")
+        return SimpleUploadedFile("extracto.csv", content.getvalue().encode("utf-8"))
+
+    def test_creates_transactions_and_reports_ignored_count(self) -> None:
+        csv_file = self._build_csv(
+            [
+                ["Compra", "01/01/2023", "10,00", "100,00"],
+                ["Suscripción", "02/01/2023", "5,00", "95,00"],
+            ]
+        )
+
+        response = self.client.post(
+            self.url,
+            {"source_name": "Cuenta bancaria", "file": csv_file},
+        )
+
+        self.assertEqual(response.status_code, 201)
+        payload = response.json()
+        self.assertEqual(payload["transactions_created"], 2)
+        self.assertEqual(payload["transactions_ignored"], 0)
+        self.assertEqual(BankTransaction.objects.count(), 2)
+        self.assertEqual(StatementImport.objects.count(), 1)
+
+    def test_returns_error_when_all_rows_are_duplicates(self) -> None:
+        statement = StatementImport.objects.create(
+            user=self.user,
+            source_name="Cuenta bancaria",
+            file_name="anterior.csv",
+        )
+        existing_raw = {
+            "Concepto": "Compra",
+            "Fecha": "01/01/2023",
+            "Importe": "10,00",
+            "Saldo disponible": "100,00",
+        }
+        BankTransaction.objects.create(
+            user=self.user,
+            statement=statement,
+            concept="Compra",
+            booking_date=date(2023, 1, 1),
+            amount="10.00",
+            available_balance="100.00",
+            raw_data=existing_raw,
+        )
+
+        csv_file = self._build_csv(
+            [["Compra", "01/01/2023", "10,00", "100,00"]]
+        )
+
+        response = self.client.post(
+            self.url,
+            {"source_name": "Cuenta bancaria", "file": csv_file},
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.json()["error"],
+            "Las entradas de este CSV ya figuran en la base de datos.",
+        )
+        self.assertEqual(StatementImport.objects.count(), 1)
+        self.assertEqual(BankTransaction.objects.count(), 1)
+
+    def test_ignores_duplicates_and_imports_new_rows(self) -> None:
+        statement = StatementImport.objects.create(
+            user=self.user,
+            source_name="Cuenta bancaria",
+            file_name="anterior.csv",
+        )
+        existing_raw = {
+            "Concepto": "Compra",
+            "Fecha": "01/01/2023",
+            "Importe": "10,00",
+            "Saldo disponible": "100,00",
+        }
+        BankTransaction.objects.create(
+            user=self.user,
+            statement=statement,
+            concept="Compra",
+            booking_date=date(2023, 1, 1),
+            amount="10.00",
+            available_balance="100.00",
+            raw_data=existing_raw,
+        )
+
+        csv_file = self._build_csv(
+            [
+                ["Compra", "01/01/2023", "10,00", "100,00"],
+                ["Suscripción", "02/01/2023", "5,00", "95,00"],
+            ]
+        )
+
+        response = self.client.post(
+            self.url,
+            {"source_name": "Cuenta bancaria", "file": csv_file},
+        )
+
+        self.assertEqual(response.status_code, 201)
+        payload = response.json()
+        self.assertEqual(payload["transactions_created"], 1)
+        self.assertEqual(payload["transactions_ignored"], 1)
+        self.assertEqual(StatementImport.objects.count(), 2)
+        self.assertEqual(BankTransaction.objects.count(), 2)

--- a/invoice_classifier/views.py
+++ b/invoice_classifier/views.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import csv
 import io
+import json
 from calendar import monthrange
 from datetime import date, datetime, timedelta
 from decimal import Decimal, InvalidOperation
@@ -403,6 +404,30 @@ def _clean_row(row: dict[str, str]) -> dict[str, str]:
     return {key: (value or "").strip() for key, value in row.items()}
 
 
+def _build_transaction_signature(
+    *,
+    concept: str,
+    booking_date: date,
+    amount: Decimal,
+    available_balance: Decimal,
+    currency: str,
+    raw_data: dict[str, str],
+) -> str:
+    """Return a stable string representing a transaction for deduplication."""
+
+    raw_json = json.dumps(raw_data, sort_keys=True, ensure_ascii=False)
+    return "|".join(
+        [
+            booking_date.isoformat(),
+            concept,
+            format(amount, "f"),
+            format(available_balance, "f"),
+            currency,
+            raw_json,
+        ]
+    )
+
+
 @login_required
 @require_http_methods(["POST"])
 def upload_statement(request: HttpRequest) -> JsonResponse:
@@ -442,6 +467,94 @@ def upload_statement(request: HttpRequest) -> JsonResponse:
         )
 
     try:
+        default_currency = BankTransaction._meta.get_field("currency").get_default()
+        parsed_rows: list[dict[str, object]] = []
+        for raw_row in reader:
+            row = _clean_row(raw_row)
+            if not any(row.values()):
+                continue
+
+            try:
+                booking_date = datetime.strptime(row["Fecha"], "%d/%m/%Y").date()
+            except ValueError as exc:
+                raise ValueError(
+                    f"La fecha '{row['Fecha']}' no tiene el formato esperado DD/MM/AAAA."
+                ) from exc
+
+            concept = row["Concepto"]
+            if not concept:
+                raise ValueError("Hay un movimiento sin concepto.")
+
+            amount = _parse_decimal(row["Importe"])
+            balance = _parse_decimal(row["Saldo disponible"])
+
+            parsed_rows.append(
+                {
+                    "concept": concept,
+                    "booking_date": booking_date,
+                    "amount": amount,
+                    "available_balance": balance,
+                    "currency": default_currency,
+                    "raw_data": row,
+                }
+            )
+
+        if not parsed_rows:
+            raise ValueError("El fichero no contiene movimientos válidos.")
+
+        concepts = {entry["concept"] for entry in parsed_rows}
+        dates = {entry["booking_date"] for entry in parsed_rows}
+        amounts = {entry["amount"] for entry in parsed_rows}
+        balances = {entry["available_balance"] for entry in parsed_rows}
+        currencies = {entry["currency"] for entry in parsed_rows}
+
+        existing_transactions = BankTransaction.objects.filter(
+            user=request.user,
+            concept__in=concepts,
+            booking_date__in=dates,
+            amount__in=amounts,
+            available_balance__in=balances,
+            currency__in=currencies,
+        )
+
+        existing_signatures = {
+            _build_transaction_signature(
+                concept=tx.concept,
+                booking_date=tx.booking_date,
+                amount=tx.amount,
+                available_balance=tx.available_balance,
+                currency=tx.currency,
+                raw_data=tx.raw_data,
+            )
+            for tx in existing_transactions
+        }
+
+        seen_signatures = set(existing_signatures)
+        deduplicated_rows: list[dict[str, object]] = []
+        ignored_count = 0
+
+        for entry in parsed_rows:
+            signature = _build_transaction_signature(
+                concept=entry["concept"],
+                booking_date=entry["booking_date"],
+                amount=entry["amount"],
+                available_balance=entry["available_balance"],
+                currency=entry["currency"],
+                raw_data=entry["raw_data"],
+            )
+            if signature in seen_signatures:
+                ignored_count += 1
+                continue
+
+            seen_signatures.add(signature)
+            deduplicated_rows.append(entry)
+
+        if not deduplicated_rows:
+            return JsonResponse(
+                {"error": "Las entradas de este CSV ya figuran en la base de datos."},
+                status=400,
+            )
+
         with transaction.atomic():
             statement = StatementImport.objects.create(
                 user=request.user,
@@ -449,37 +562,19 @@ def upload_statement(request: HttpRequest) -> JsonResponse:
                 file_name=uploaded_file.name,
             )
 
-            transactions: list[BankTransaction] = []
-            for raw_row in reader:
-                row = _clean_row(raw_row)
-                if not any(row.values()):
-                    continue
-
-                try:
-                    booking_date = datetime.strptime(row["Fecha"], "%d/%m/%Y").date()
-                except ValueError as exc:
-                    raise ValueError(
-                        f"La fecha '{row['Fecha']}' no tiene el formato esperado DD/MM/AAAA."
-                    ) from exc
-
-                concept = row["Concepto"]
-                if not concept:
-                    raise ValueError("Hay un movimiento sin concepto.")
-
-                amount = _parse_decimal(row["Importe"])
-                balance = _parse_decimal(row["Saldo disponible"])
-
-                transactions.append(
-                    BankTransaction(
-                        user=request.user,
-                        statement=statement,
-                        concept=concept,
-                        booking_date=booking_date,
-                        amount=amount,
-                        available_balance=balance,
-                        raw_data=row,
-                    )
+            transactions = [
+                BankTransaction(
+                    user=request.user,
+                    statement=statement,
+                    concept=entry["concept"],
+                    booking_date=entry["booking_date"],
+                    amount=entry["amount"],
+                    available_balance=entry["available_balance"],
+                    currency=entry["currency"],
+                    raw_data=entry["raw_data"],
                 )
+                for entry in deduplicated_rows
+            ]
 
             BankTransaction.objects.bulk_create(transactions)
     except ValueError as exc:
@@ -489,6 +584,7 @@ def upload_statement(request: HttpRequest) -> JsonResponse:
         {
             "statement_id": statement.id,
             "transactions_created": len(transactions),
+            "transactions_ignored": ignored_count,
             "file_name": statement.file_name,
         },
         status=201,


### PR DESCRIPTION
## Summary
- avoid importing transactions whose fields already exist for the user
- report how many rows from the CSV were ignored for being duplicates
- adjust the upload success message and add tests covering the new behaviour

## Testing
- python manage.py test *(fails: Django is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e99ab9bbac832f95bbd69dba36f6d5